### PR TITLE
create shallow relatedToOne objects from relationships hashes

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -2740,27 +2740,27 @@ function getRelatedRecords(record, property) {
   return new RelatedRecordsArray(relatedRecords, record, relationType);
 }
 /**
- * Handles getting polymorphic has_one/belong_to.
+ * Gets a single related record from the store for relatedToOne relationships.
+ * 1. Gets the relationships hash of a record.
+ * 2. Identifies the correct relationship within the hash
+ * 3. Uses the id and type to either get a record from the store, or create a model using the type and id
  *
  * @method getRelatedRecord
  */
 
 function getRelatedRecord(record, property) {
+  var _relationships$relati;
+
   var modelType = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
-  // Get relationships
-  var relationships = record.relationships; // Short circuit if no relationships are present
-
-  if (!relationships) return; // Use property name unless model type is provided
-
+  var relationships = record.relationships;
+  if (!relationships) return;
   var relationType = modelType ? singularizeType(modelType) : property;
-  var reference = relationships[relationType]; // Short circuit if matching reference is not found
-
-  if (!reference || !reference.data) return;
-  var _reference$data = reference.data,
-      id = _reference$data.id,
-      type = _reference$data.type;
+  var relatedData = (_relationships$relati = relationships[relationType]) === null || _relationships$relati === void 0 ? void 0 : _relationships$relati.data;
+  if (!relatedData) return;
+  var id = relatedData.id,
+      type = relatedData.type;
   var recordType = modelType || type;
-  return record.store.getRecord(recordType, id);
+  return record.store.getOne(recordType, id) || record.store.createModel(type, id, {});
 }
 /**
  * Handles setting polymorphic has_one/belong_to.

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -2708,27 +2708,27 @@ function getRelatedRecords(record, property) {
   return new RelatedRecordsArray(relatedRecords, record, relationType);
 }
 /**
- * Handles getting polymorphic has_one/belong_to.
+ * Gets a single related record from the store for relatedToOne relationships.
+ * 1. Gets the relationships hash of a record.
+ * 2. Identifies the correct relationship within the hash
+ * 3. Uses the id and type to either get a record from the store, or create a model using the type and id
  *
  * @method getRelatedRecord
  */
 
 function getRelatedRecord(record, property) {
+  var _relationships$relati;
+
   var modelType = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
-  // Get relationships
-  var relationships = record.relationships; // Short circuit if no relationships are present
-
-  if (!relationships) return; // Use property name unless model type is provided
-
+  var relationships = record.relationships;
+  if (!relationships) return;
   var relationType = modelType ? singularizeType(modelType) : property;
-  var reference = relationships[relationType]; // Short circuit if matching reference is not found
-
-  if (!reference || !reference.data) return;
-  var _reference$data = reference.data,
-      id = _reference$data.id,
-      type = _reference$data.type;
+  var relatedData = (_relationships$relati = relationships[relationType]) === null || _relationships$relati === void 0 ? void 0 : _relationships$relati.data;
+  if (!relatedData) return;
+  var id = relatedData.id,
+      type = relatedData.type;
   var recordType = modelType || type;
-  return record.store.getRecord(recordType, id);
+  return record.store.getOne(recordType, id) || record.store.createModel(type, id, {});
 }
 /**
  * Handles setting polymorphic has_one/belong_to.

--- a/docs/classes/Model.html
+++ b/docs/classes/Model.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/RelatedRecordsArray.html
+++ b/docs/classes/RelatedRecordsArray.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -84,7 +84,7 @@
 
 
         <div class="foundat">
-            Defined in: <a href="../files/src_decorators_relationships.js.html#l205"><code>src&#x2F;decorators&#x2F;relationships.js:205</code></a>
+            Defined in: <a href="../files/src_decorators_relationships.js.html#l203"><code>src&#x2F;decorators&#x2F;relationships.js:203</code></a>
         </div>
 
 
@@ -125,7 +125,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l205"><code>src&#x2F;decorators&#x2F;relationships.js:205</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l203"><code>src&#x2F;decorators&#x2F;relationships.js:203</code></a>
         </p>
 
 
@@ -274,7 +274,7 @@
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l236"><code>src&#x2F;decorators&#x2F;relationships.js:236</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l234"><code>src&#x2F;decorators&#x2F;relationships.js:234</code></a>
         </p>
 
 
@@ -404,7 +404,12 @@ Attributes can be defined with a default.</p>
     </div>
 
     <div class="description">
-        <p>Handles getting polymorphic has_one/belong_to.</p>
+        <p>Gets a single related record from the store for relatedToOne relationships.</p>
+<ol>
+<li>Gets the relationships hash of a record.</li>
+<li>Identifies the correct relationship within the hash</li>
+<li>Uses the id and type to either get a record from the store, or create a model using the type and id</li>
+</ol>
 
     </div>
 
@@ -614,7 +619,7 @@ everything the same except it only returns a single record.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l290"><code>src&#x2F;decorators&#x2F;relationships.js:290</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l288"><code>src&#x2F;decorators&#x2F;relationships.js:288</code></a>
         </p>
 
 
@@ -686,7 +691,7 @@ everything the same except it only returns a single record.</p>
     <div class="meta">
                 <p>
                 Defined in
-        <a href="../files/src_decorators_relationships.js.html#l146"><code>src&#x2F;decorators&#x2F;relationships.js:146</code></a>
+        <a href="../files/src_decorators_relationships.js.html#l144"><code>src&#x2F;decorators&#x2F;relationships.js:144</code></a>
         </p>
 
 

--- a/docs/classes/Schema.html
+++ b/docs/classes/Schema.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/classes/Store.html
+++ b/docs/classes/Store.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/data.json
+++ b/docs/data.json
@@ -3,7 +3,7 @@
         "name": "mobx-async-store",
         "description": "Asyc Data Store for mobx",
         "url": "https://github.com/artemis-ag/mobx-async-store",
-        "version": "3.10.1"
+        "version": "3.11.0"
     },
     "files": {
         "src/decorators/attributes.js": {
@@ -68,7 +68,7 @@
             "plugin_for": [],
             "extension_for": [],
             "file": "src/decorators/relationships.js",
-            "line": 205,
+            "line": 203,
             "description": "An array that allows for updating store references and relationships",
             "is_constructor": 1,
             "params": [
@@ -220,14 +220,14 @@
         {
             "file": "src/decorators/relationships.js",
             "line": 121,
-            "description": "Handles getting polymorphic has_one/belong_to.",
+            "description": "Gets a single related record from the store for relatedToOne relationships.\n1. Gets the relationships hash of a record.\n2. Identifies the correct relationship within the hash\n3. Uses the id and type to either get a record from the store, or create a model using the type and id",
             "itemtype": "method",
             "name": "getRelatedRecord",
             "class": "RelatedRecordsArray"
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 146,
+            "line": 144,
             "description": "Handles setting polymorphic has_one/belong_to.\n- Validates the related record to make sure it inherits from `Model` class\n- Sets the relationship\n- Attempts to find an inverse relationship, and if successful adds it as well",
             "itemtype": "method",
             "name": "setRelatedRecord",
@@ -257,7 +257,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 236,
+            "line": 234,
             "description": "Adds a record to the array, and updates references in the store, as well as inverse references",
             "itemtype": "method",
             "name": "add",
@@ -276,7 +276,7 @@
         },
         {
             "file": "src/decorators/relationships.js",
-            "line": 290,
+            "line": 288,
             "description": "Removes a record from the array, and updates references in the store, as well as inverse references",
             "itemtype": "method",
             "name": "remove",

--- a/docs/files/src_Model.js.html
+++ b/docs/files/src_Model.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_Store.js.html
+++ b/docs/files/src_Store.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_attributes.js.html
+++ b/docs/files/src_decorators_attributes.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_decorators_relationships.js.html
+++ b/docs/files/src_decorators_relationships.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">
@@ -204,28 +204,26 @@ export function getRelatedRecords (record, property, modelType = null) {
 }
 
 /**
- * Handles getting polymorphic has_one/belong_to.
+ * Gets a single related record from the store for relatedToOne relationships.
+ * 1. Gets the relationships hash of a record.
+ * 2. Identifies the correct relationship within the hash
+ * 3. Uses the id and type to either get a record from the store, or create a model using the type and id
  *
  * @method getRelatedRecord
  */
 export function getRelatedRecord (record, property, modelType = null) {
-  // Get relationships
   const { relationships } = record
-
-  // Short circuit if no relationships are present
   if (!relationships) return
 
-  // Use property name unless model type is provided
   const relationType = modelType ? singularizeType(modelType) : property
-  const reference = relationships[relationType]
+  const relatedData = relationships[relationType]?.data
 
-  // Short circuit if matching reference is not found
-  if (!reference || !reference.data) return
+  if (!relatedData) return
 
-  const { id, type } = reference.data
+  const { id, type } = relatedData
   const recordType = modelType || type
 
-  return record.store.getRecord(recordType, id)
+  return record.store.getOne(recordType, id) || record.store.createModel(type, id, {})
 }
 
 /**

--- a/docs/files/src_schema.js.html
+++ b/docs/files/src_schema.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/files/src_utils.js.html
+++ b/docs/files/src_utils.js.html
@@ -17,7 +17,7 @@
                 <h1><img src="../assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
                 <h1><img src="./assets/css/logo.png" title="mobx-async-store" width="117" height="52"></h1>
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 3.10.1</em>
+            <em>API Docs for: 3.11.0</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "3.10.1",
+  "version": "3.11.0",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",
   "main": "dist/mobx-async-store.cjs.js",

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -1242,6 +1242,24 @@ describe('Store', () => {
       expect(todo.category.name).toEqual(category.name)
     })
 
+    it('creates a shallow related model with a relatedToOne property not already in the store', () => {
+      const todoData = {
+        attributes: { title: 'hello!' },
+        relationships: {
+          category: { data: { id: '1', type: 'categories' } }
+        }
+      }
+      const todo = store.createModel('todos', 1, todoData)
+      expect(todo.id).toEqual(1)
+      expect(todo.category.id).toEqual('1')
+      expect(todo.category.type).toEqual('categories')
+      expect(todo.category.name).toBe('')
+
+      store.createOrUpdateModel({ id: '1', type: 'categories', attributes: { name: 'Cat5' } })
+
+      expect(todo.category.name).toEqual('Cat5')
+    })
+
     it('creates a model with relatedToMany property', () => {
       const tag = store.add('tags', { id: 3, label: 'Tag #3' })
       const todoData = {

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -16,6 +16,7 @@
   "plugins": [
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     ["@babel/plugin-proposal-class-properties", { "loose": true }],
+    ["@babel/plugin-proposal-private-methods", { "loose": true }],
     "@babel/plugin-transform-runtime"
   ]
 }

--- a/src/decorators/relationships.js
+++ b/src/decorators/relationships.js
@@ -119,28 +119,26 @@ export function getRelatedRecords (record, property, modelType = null) {
 }
 
 /**
- * Handles getting polymorphic has_one/belong_to.
+ * Gets a single related record from the store for relatedToOne relationships.
+ * 1. Gets the relationships hash of a record.
+ * 2. Identifies the correct relationship within the hash
+ * 3. Uses the id and type to either get a record from the store, or create a model using the type and id
  *
  * @method getRelatedRecord
  */
 export function getRelatedRecord (record, property, modelType = null) {
-  // Get relationships
   const { relationships } = record
-
-  // Short circuit if no relationships are present
   if (!relationships) return
 
-  // Use property name unless model type is provided
   const relationType = modelType ? singularizeType(modelType) : property
-  const reference = relationships[relationType]
+  const relatedData = relationships[relationType]?.data
 
-  // Short circuit if matching reference is not found
-  if (!reference || !reference.data) return
+  if (!relatedData) return
 
-  const { id, type } = reference.data
+  const { id, type } = relatedData
   const recordType = modelType || type
 
-  return record.store.getRecord(recordType, id)
+  return record.store.getOne(recordType, id) || record.store.createModel(type, id, {})
 }
 
 /**


### PR DESCRIPTION
### Current

When loading models into the store, a `relationships` hash is added to each model. when the relationship is accessed, the model then looks in the store for the related object. However, if the model has not yet been loaded, nothing will be returned

```js
const todoData = {
  attributes: { title: 'hello!' },
  relationships: {
    category: { data: { id: '1', type: 'categories' } }
  }
}

const todo = store.createModel('todos', '1', todoData)

todo.category
=> undefined

todo.relationships.category.data.id
=> '1'

store.createModel('categories', '1', attributes: { name: 'Cat5' })

todo.category
=> Category { id: '1', type: 'categories', name: 'Cat5' }
```

### Proposal
Since we already have the relationship id and type, we should instantiate a model with just that information. (1) If it has been returned from the server, it is potentially useful to the application (for grouping, conditionals for polymorphism, etc). (2) It will be updated from the server if the model is later loaded.

```js
const todoData = {
  attributes: { title: 'hello!' },
  relationships: {
    category: { data: { id: '1', type: 'categories' } }
  }
}

const todo = store.createModel('todos', '1', todoData)

todo.category
=> Category { id: '1', type: 'categories' }

store.createModel('categories', '1', attributes: { name: 'Cat5' })

todo.category
=> Category { id: '1', type: 'categories', name: 'Cat5' }
```

### Tradeoffs
Current applications may use a `null` check on relationships as a proxy to see if data has been loaded into the store yet. This has the potential to invalidate those checks. *However*, this would allow a more targeted approach to conditionals based on model properties.