### PR TITLE
retry failed fetches

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -69,18 +69,18 @@ var _wrapNativeSuper__default = /*#__PURE__*/_interopDefaultLegacy(_wrapNativeSu
 
 var QueryString = {
   parse: function parse(str) {
-    return qs__default["default"].parse(str, {
+    return qs__default['default'].parse(str, {
       ignoreQueryPrefix: true
     });
   },
   stringify: function stringify(str) {
-    return qs__default["default"].stringify(str, {
+    return qs__default['default'].stringify(str, {
       arrayFormat: 'brackets'
     });
   }
 };
 
-function _wrapRegExp() { _wrapRegExp = function _wrapRegExp(re, groups) { return new BabelRegExp(re, undefined, groups); }; var _super = RegExp.prototype; var _groups = new WeakMap(); function BabelRegExp(re, flags, groups) { var _this = new RegExp(re, flags); _groups.set(_this, groups || _groups.get(re)); return _setPrototypeOf__default["default"](_this, BabelRegExp.prototype); } _inherits__default["default"](BabelRegExp, RegExp); BabelRegExp.prototype.exec = function (str) { var result = _super.exec.call(this, str); if (result) result.groups = buildGroups(result, this); return result; }; BabelRegExp.prototype[Symbol.replace] = function (str, substitution) { if (typeof substitution === "string") { var groups = _groups.get(this); return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)>/g, function (_, name) { return "$" + groups[name]; })); } else if (typeof substitution === "function") { var _this = this; return _super[Symbol.replace].call(this, str, function () { var args = arguments; if (_typeof__default["default"](args[args.length - 1]) !== "object") { args = [].slice.call(args); args.push(buildGroups(args, _this)); } return substitution.apply(this, args); }); } else { return _super[Symbol.replace].call(this, str, substitution); } }; function buildGroups(result, re) { var g = _groups.get(re); return Object.keys(g).reduce(function (groups, name) { groups[name] = result[g[name]]; return groups; }, Object.create(null)); } return _wrapRegExp.apply(this, arguments); }
+function _wrapRegExp() { _wrapRegExp = function _wrapRegExp(re, groups) { return new BabelRegExp(re, undefined, groups); }; var _super = RegExp.prototype; var _groups = new WeakMap(); function BabelRegExp(re, flags, groups) { var _this = new RegExp(re, flags); _groups.set(_this, groups || _groups.get(re)); return _setPrototypeOf__default['default'](_this, BabelRegExp.prototype); } _inherits__default['default'](BabelRegExp, RegExp); BabelRegExp.prototype.exec = function (str) { var result = _super.exec.call(this, str); if (result) result.groups = buildGroups(result, this); return result; }; BabelRegExp.prototype[Symbol.replace] = function (str, substitution) { if (typeof substitution === "string") { var groups = _groups.get(this); return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)>/g, function (_, name) { return "$" + groups[name]; })); } else if (typeof substitution === "function") { var _this = this; return _super[Symbol.replace].call(this, str, function () { var args = arguments; if (_typeof__default['default'](args[args.length - 1]) !== "object") { args = [].slice.call(args); args.push(buildGroups(args, _this)); } return substitution.apply(this, args); }); } else { return _super[Symbol.replace].call(this, str, substitution); } }; function buildGroups(result, re) { var g = _groups.get(re); return Object.keys(g).reduce(function (groups, name) { groups[name] = result[g[name]]; return groups; }, Object.create(null)); } return _wrapRegExp.apply(this, arguments); }
 var pending = {};
 var counter = {};
 var URL_MAX_LENGTH = 1024;
@@ -113,8 +113,8 @@ function singularizeType(recordType) {
   var typeParts = recordType.split('_');
   var endPart = typeParts[typeParts.length - 1];
   typeParts = typeParts.slice(0, -1);
-  endPart = pluralize__default["default"].singular(endPart);
-  return [].concat(_toConsumableArray__default["default"](typeParts), [endPart]).join('_');
+  endPart = pluralize__default['default'].singular(endPart);
+  return [].concat(_toConsumableArray__default['default'](typeParts), [endPart]).join('_');
 }
 /**
  * Build request url from base url, endpoint, query params, and ids.
@@ -162,27 +162,49 @@ function combineRacedRequests(key, fn) {
   var incrementBlocked = incrementor(key);
   var decrementBlocked = decrementor(key); // keep track of the number of callers waiting for this promise to resolve
 
-  incrementBlocked();
+  incrementBlocked(); // Add the current call to our pending list in case another request comes in
+  // before it resolves. If there is a request already pending, we'll use the
+  // existing one instead
 
-  function handleResponse(response) {
-    var count = decrementBlocked(); // if there are other callers waiting for this request to resolve, we should
-    // clone the response before returning so that we can re-use it for the
-    // remaining callers
+  if (!pending[key]) {
+    pending[key] = fn.call();
+  }
 
-    if (count > 0) return response.clone(); // if there are no more callers waiting for this promise to resolve (i.e. if
+  return pending[key].finally(function () {
+    var count = decrementBlocked(); // if there are no more callers waiting for this promise to resolve (i.e. if
     // this is the last one), we can remove the reference to the pending promise
     // allowing subsequent requests to proceed unblocked.
 
-    delete pending[key];
-    return response;
-  } // Return pending promise if one already exists
+    if (count === 0) delete pending[key];
+  }).then( // if there are other callers waiting for this request to resolve, clone the
+  // response before returning so that we can re-use it for the remaining callers
+  function (response) {
+    return response.clone();
+  }, // Bubble the error up to be handled by the consuming code
+  function (error) {
+    return Promise.reject(error);
+  });
+}
+function fetchWithRetry(url, fetchOptions, attempts, delay) {
+  var key = JSON.stringify({
+    url: url,
+    fetchOptions: fetchOptions
+  });
+  return combineRacedRequests(key, function () {
+    return fetch(url, fetchOptions);
+  }).catch(function (error) {
+    var attemptsRemaining = attempts - 1;
 
+    if (!attemptsRemaining) {
+      throw error;
+    }
 
-  if (pending[key]) return pending[key].then(handleResponse); // Otherwise call the method and on resolution
-  // clear out the pending promise for the key
-
-  pending[key] = fn.call();
-  return pending[key].then(handleResponse);
+    return new Promise(function (resolve) {
+      return setTimeout(resolve, delay);
+    }).then(function () {
+      return fetchWithRetry(url, fetchOptions, attemptsRemaining, delay);
+    });
+  });
 }
 /**
  * convert a value into a date, pass Date or Moment instances thru
@@ -207,7 +229,7 @@ function makeDate(value) {
  */
 
 function walk(obj, iteratee, prefix) {
-  if (obj != null && _typeof__default["default"](obj) === 'object') {
+  if (obj != null && _typeof__default['default'](obj) === 'object') {
     return Object.keys(obj).map(function (prop) {
       return walk(obj[prop], iteratee, [prefix, prop].filter(function (x) {
         return x;
@@ -232,8 +254,8 @@ function walk(obj, iteratee, prefix) {
 function diff() {
   var a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-  return flattenDeep__default["default"](walk(a, function (prevValue, path) {
-    var currValue = dig__default["default"](b, path);
+  return flattenDeep__default['default'](walk(a, function (prevValue, path) {
+    var currValue = dig__default['default'](b, path);
     return prevValue === currValue ? undefined : path;
   })).filter(function (x) {
     return x;
@@ -273,7 +295,7 @@ function parseErrorPointer() {
     key: 2
   });
 
-  var match = dig__default["default"](error, 'source.pointer', '').match(regex);
+  var match = dig__default['default'](error, 'source.pointer', '').match(regex);
 
   var _ref = (match === null || match === void 0 ? void 0 : match.groups) || {},
       _ref$index = _ref.index,
@@ -321,14 +343,14 @@ function deriveIdQueryStrings(ids) {
  */
 var Schema = /*#__PURE__*/function () {
   function Schema() {
-    _classCallCheck__default["default"](this, Schema);
+    _classCallCheck__default['default'](this, Schema);
 
-    _defineProperty__default["default"](this, "structure", {});
+    _defineProperty__default['default'](this, "structure", {});
 
-    _defineProperty__default["default"](this, "relations", {});
+    _defineProperty__default['default'](this, "relations", {});
   }
 
-  _createClass__default["default"](Schema, [{
+  _createClass__default['default'](Schema, [{
     key: "addAttribute",
     value: function addAttribute(_ref) {
       var type = _ref.type,
@@ -381,7 +403,7 @@ var _class$1, _descriptor$1;
 
 function ownKeys$4(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread$4(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$4(Object(source), true).forEach(function (key) { _defineProperty__default["default"](target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$4(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread$4(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$4(Object(source), true).forEach(function (key) { _defineProperty__default['default'](target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$4(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 /**
  * Maps the passed-in property names through and runs validations against those properties
  * @method validateProperties
@@ -409,7 +431,7 @@ function stringifyIds(object) {
   Object.keys(object).forEach(function (key) {
     var property = object[key];
 
-    if (_typeof__default["default"](property) === 'object') {
+    if (_typeof__default['default'](property) === 'object') {
       if (property.id) {
         property.id = String(property.id);
       }
@@ -456,13 +478,13 @@ var Model = (_class$1 = /*#__PURE__*/function () {
   function Model() {
     var initialAttributes = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
-    _classCallCheck__default["default"](this, Model);
+    _classCallCheck__default['default'](this, Model);
 
-    _defineProperty__default["default"](this, "isInFlight", false);
+    _defineProperty__default['default'](this, "isInFlight", false);
 
-    _initializerDefineProperty__default["default"](this, "errors", _descriptor$1, this);
+    _initializerDefineProperty__default['default'](this, "errors", _descriptor$1, this);
 
-    _defineProperty__default["default"](this, "_snapshots", []);
+    _defineProperty__default['default'](this, "_snapshots", []);
 
     mobx.makeObservable(this);
     var defaultAttributes = this.defaultAttributes;
@@ -520,7 +542,7 @@ var Model = (_class$1 = /*#__PURE__*/function () {
    */
 
 
-  _createClass__default["default"](Model, [{
+  _createClass__default['default'](Model, [{
     key: "isDirty",
     get: function get() {
       return this.dirtyAttributes.length > 0 || this.dirtyRelationships.length > 0;
@@ -551,13 +573,13 @@ var Model = (_class$1 = /*#__PURE__*/function () {
         var currentValue = _this2.attributes[attr];
         var previousValue = _this2.previousSnapshot.attributes[attr];
 
-        if (isObject__default["default"](currentValue)) {
+        if (isObject__default['default'](currentValue)) {
           var currentToPreviousDiff = diff(currentValue, previousValue);
           var previousToCurrentDiff = diff(previousValue, currentValue);
-          union__default["default"](currentToPreviousDiff, previousToCurrentDiff).forEach(function (property) {
+          union__default['default'](currentToPreviousDiff, previousToCurrentDiff).forEach(function (property) {
             dirtyAccumulator.add("".concat(attr, ".").concat(property));
           });
-        } else if (!isEqual__default["default"](previousValue, currentValue)) {
+        } else if (!isEqual__default['default'](previousValue, currentValue)) {
           dirtyAccumulator.add(attr);
         }
 
@@ -603,7 +625,7 @@ var Model = (_class$1 = /*#__PURE__*/function () {
           return [value.id, value.type];
         }).sort() : [previousValues.id, previousValues.type];
 
-        if (!isEqual__default["default"](currentIds, previousIds)) {
+        if (!isEqual__default['default'](currentIds, previousIds)) {
           dirtyAccumulator.add(name);
         }
 
@@ -828,9 +850,9 @@ var Model = (_class$1 = /*#__PURE__*/function () {
 
       _this.errors = {};
       return promise.then( /*#__PURE__*/function () {
-        var _ref = _asyncToGenerator__default["default"]( /*#__PURE__*/_regeneratorRuntime__default["default"].mark(function _callee(response) {
+        var _ref = _asyncToGenerator__default['default']( /*#__PURE__*/_regeneratorRuntime__default['default'].mark(function _callee(response) {
           var json;
-          return _regeneratorRuntime__default["default"].wrap(function _callee$(_context) {
+          return _regeneratorRuntime__default['default'].wrap(function _callee$(_context) {
             while (1) {
               switch (_context.prev = _context.next) {
                 case 0:
@@ -962,7 +984,7 @@ var Model = (_class$1 = /*#__PURE__*/function () {
   }, {
     key: "persistedSnapshot",
     get: function get() {
-      return findLast__default["default"](this._snapshots, function (ss) {
+      return findLast__default['default'](this._snapshots, function (ss) {
         return ss.persisted;
       }) || this._snapshots[0];
     }
@@ -1286,8 +1308,8 @@ var Model = (_class$1 = /*#__PURE__*/function () {
   }, {
     key: "clone",
     value: function clone() {
-      var attributes = cloneDeep__default["default"](this.snapshot.attributes);
-      var relationships = cloneDeep__default["default"](this.snapshot.relationships);
+      var attributes = cloneDeep__default['default'](this.snapshot.attributes);
+      var relationships = cloneDeep__default['default'](this.snapshot.relationships);
       return this.store.createModel(this.type, this.id, {
         attributes: attributes,
         relationships: relationships
@@ -1312,7 +1334,7 @@ var Model = (_class$1 = /*#__PURE__*/function () {
   }]);
 
   return Model;
-}(), (_applyDecoratedDescriptor__default["default"](_class$1.prototype, "isNew", [mobx.computed], Object.getOwnPropertyDescriptor(_class$1.prototype, "isNew"), _class$1.prototype), _descriptor$1 = _applyDecoratedDescriptor__default["default"](_class$1.prototype, "errors", [mobx.observable], {
+}(), (_applyDecoratedDescriptor__default['default'](_class$1.prototype, "isNew", [mobx.computed], Object.getOwnPropertyDescriptor(_class$1.prototype, "isNew"), _class$1.prototype), _descriptor$1 = _applyDecoratedDescriptor__default['default'](_class$1.prototype, "errors", [mobx.observable], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -1325,7 +1347,7 @@ var _class, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5,
 
 function ownKeys$3(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread$3(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$3(Object(source), true).forEach(function (key) { _defineProperty__default["default"](target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$3(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread$3(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$3(Object(source), true).forEach(function (key) { _defineProperty__default['default'](target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$3(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 /**
  * Defines the Artemis Data Store class.
  *
@@ -1366,17 +1388,17 @@ var Store = (_class = /*#__PURE__*/function () {
   function Store(_options) {
     var _this = this;
 
-    _classCallCheck__default["default"](this, Store);
+    _classCallCheck__default['default'](this, Store);
 
-    _initializerDefineProperty__default["default"](this, "data", _descriptor, this);
+    _initializerDefineProperty__default['default'](this, "data", _descriptor, this);
 
-    _initializerDefineProperty__default["default"](this, "lastResponseHeaders", _descriptor2, this);
+    _initializerDefineProperty__default['default'](this, "lastResponseHeaders", _descriptor2, this);
 
-    _defineProperty__default["default"](this, "loadingStates", mobx.observable.map());
+    _defineProperty__default['default'](this, "loadingStates", mobx.observable.map());
 
-    _defineProperty__default["default"](this, "genericErrorMessage", 'Something went wrong.');
+    _defineProperty__default['default'](this, "genericErrorMessage", 'Something went wrong.');
 
-    _defineProperty__default["default"](this, "add", function (type, data) {
+    _defineProperty__default['default'](this, "add", function (type, data) {
       if (data.constructor.name === 'Array') {
         return _this.addModels(type, data);
       } else {
@@ -1384,14 +1406,14 @@ var Store = (_class = /*#__PURE__*/function () {
       }
     });
 
-    _defineProperty__default["default"](this, "pickAttributes", function (properties, type) {
+    _defineProperty__default['default'](this, "pickAttributes", function (properties, type) {
       var attributeNames = Object.keys(_this.schema.structure[type]);
-      return pick__default["default"](properties, attributeNames);
+      return pick__default['default'](properties, attributeNames);
     });
 
-    _defineProperty__default["default"](this, "pickRelationships", function (properties, type) {
+    _defineProperty__default['default'](this, "pickRelationships", function (properties, type) {
       var relationshipNames = Object.keys(_this.schema.relations[type] || {});
-      var allRelationships = pick__default["default"](properties, relationshipNames);
+      var allRelationships = pick__default['default'](properties, relationshipNames);
       return Object.keys(allRelationships).reduce(function (references, key) {
         var relatedModel = allRelationships[key];
         var data;
@@ -1417,7 +1439,7 @@ var Store = (_class = /*#__PURE__*/function () {
       }, {});
     });
 
-    _defineProperty__default["default"](this, "build", function (type, properties) {
+    _defineProperty__default['default'](this, "build", function (type, properties) {
       var id = idOrNewId(properties.id);
 
       var attributes = _this.pickAttributes(properties, type);
@@ -1429,9 +1451,9 @@ var Store = (_class = /*#__PURE__*/function () {
       return model;
     });
 
-    _initializerDefineProperty__default["default"](this, "addModel", _descriptor3, this);
+    _initializerDefineProperty__default['default'](this, "addModel", _descriptor3, this);
 
-    _defineProperty__default["default"](this, "addModels", function (type, data) {
+    _defineProperty__default['default'](this, "addModels", function (type, data) {
       return mobx.runInAction(function () {
         return data.map(function (obj) {
           return _this.addModel(type, obj);
@@ -1439,8 +1461,8 @@ var Store = (_class = /*#__PURE__*/function () {
       });
     });
 
-    _defineProperty__default["default"](this, "bulkSave", /*#__PURE__*/function () {
-      var _ref = _asyncToGenerator__default["default"]( /*#__PURE__*/_regeneratorRuntime__default["default"].mark(function _callee(type, records) {
+    _defineProperty__default['default'](this, "bulkSave", /*#__PURE__*/function () {
+      var _ref = _asyncToGenerator__default['default']( /*#__PURE__*/_regeneratorRuntime__default['default'].mark(function _callee(type, records) {
         var options,
             queryParams,
             extensions,
@@ -1450,7 +1472,7 @@ var Store = (_class = /*#__PURE__*/function () {
             extensionStr,
             response,
             _args = arguments;
-        return _regeneratorRuntime__default["default"].wrap(function _callee$(_context) {
+        return _regeneratorRuntime__default['default'].wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
@@ -1487,14 +1509,14 @@ var Store = (_class = /*#__PURE__*/function () {
         }, _callee);
       }));
 
-      return function (_x2, _x3) {
+      return function (_x, _x2) {
         return _ref.apply(this, arguments);
       };
     }());
 
-    _initializerDefineProperty__default["default"](this, "remove", _descriptor4, this);
+    _initializerDefineProperty__default['default'](this, "remove", _descriptor4, this);
 
-    _defineProperty__default["default"](this, "getOne", function (type, id) {
+    _defineProperty__default['default'](this, "getOne", function (type, id) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
       if (!id) {
@@ -1511,7 +1533,7 @@ var Store = (_class = /*#__PURE__*/function () {
       }
     });
 
-    _defineProperty__default["default"](this, "findOne", function (type, id) {
+    _defineProperty__default['default'](this, "findOne", function (type, id) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
       if (!id) {
@@ -1528,7 +1550,7 @@ var Store = (_class = /*#__PURE__*/function () {
       }
     });
 
-    _defineProperty__default["default"](this, "getMany", function (type, ids) {
+    _defineProperty__default['default'](this, "getMany", function (type, ids) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
       var idsToQuery = ids.slice().map(String);
 
@@ -1539,7 +1561,7 @@ var Store = (_class = /*#__PURE__*/function () {
       });
     });
 
-    _defineProperty__default["default"](this, "fetchMany", function (type, ids) {
+    _defineProperty__default['default'](this, "fetchMany", function (type, ids) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
       var idsToQuery = ids.slice().map(String);
       var _options$queryParams = options.queryParams,
@@ -1560,13 +1582,13 @@ var Store = (_class = /*#__PURE__*/function () {
       return Promise.all(queries).then(function (records) {
         var _ref2;
 
-        return (_ref2 = []).concat.apply(_ref2, _toConsumableArray__default["default"](records));
+        return (_ref2 = []).concat.apply(_ref2, _toConsumableArray__default['default'](records));
       }).catch(function (err) {
         return Promise.reject(err);
       });
     });
 
-    _defineProperty__default["default"](this, "findMany", function (type, ids) {
+    _defineProperty__default['default'](this, "findMany", function (type, ids) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
       var idsToQuery = ids.slice().map(String);
 
@@ -1601,11 +1623,11 @@ var Store = (_class = /*#__PURE__*/function () {
         });
       }));
       return query.then(function (recordsFromServer) {
-        return recordsInStore.concat.apply(recordsInStore, _toConsumableArray__default["default"](recordsFromServer));
+        return recordsInStore.concat.apply(recordsInStore, _toConsumableArray__default['default'](recordsFromServer));
       });
     });
 
-    _defineProperty__default["default"](this, "getAll", function (type) {
+    _defineProperty__default['default'](this, "getAll", function (type) {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       var queryParams = options.queryParams;
 
@@ -1616,12 +1638,12 @@ var Store = (_class = /*#__PURE__*/function () {
       }
     });
 
-    _initializerDefineProperty__default["default"](this, "setLoadingState", _descriptor5, this);
+    _initializerDefineProperty__default['default'](this, "setLoadingState", _descriptor5, this);
 
-    _initializerDefineProperty__default["default"](this, "deleteLoadingState", _descriptor6, this);
+    _initializerDefineProperty__default['default'](this, "deleteLoadingState", _descriptor6, this);
 
-    _defineProperty__default["default"](this, "fetchAll", /*#__PURE__*/function () {
-      var _ref4 = _asyncToGenerator__default["default"]( /*#__PURE__*/_regeneratorRuntime__default["default"].mark(function _callee2(type) {
+    _defineProperty__default['default'](this, "fetchAll", /*#__PURE__*/function () {
+      var _ref4 = _asyncToGenerator__default['default']( /*#__PURE__*/_regeneratorRuntime__default['default'].mark(function _callee2(type) {
         var options,
             queryParams,
             url,
@@ -1630,7 +1652,7 @@ var Store = (_class = /*#__PURE__*/function () {
             json,
             records,
             _args2 = arguments;
-        return _regeneratorRuntime__default["default"].wrap(function _callee2$(_context2) {
+        return _regeneratorRuntime__default['default'].wrap(function _callee2$(_context2) {
           while (1) {
             switch (_context2.prev = _context2.next) {
               case 0:
@@ -1680,7 +1702,7 @@ var Store = (_class = /*#__PURE__*/function () {
 
                     var cachedIds = _this.data[type].cache.get(url);
 
-                    _this.data[type].cache.set(url, [].concat(_toConsumableArray__default["default"](cachedIds), [id]));
+                    _this.data[type].cache.set(url, [].concat(_toConsumableArray__default['default'](cachedIds), [id]));
 
                     _this.data[type].records.set(String(id), record);
 
@@ -1712,12 +1734,12 @@ var Store = (_class = /*#__PURE__*/function () {
         }, _callee2);
       }));
 
-      return function (_x4) {
+      return function (_x3) {
         return _ref4.apply(this, arguments);
       };
     }());
 
-    _defineProperty__default["default"](this, "findAll", function (type) {
+    _defineProperty__default['default'](this, "findAll", function (type) {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
       var records = _this.getAll(type, options);
@@ -1748,7 +1770,7 @@ var Store = (_class = /*#__PURE__*/function () {
    */
 
 
-  _createClass__default["default"](Store, [{
+  _createClass__default['default'](Store, [{
     key: "fetchOne",
     value:
     /**
@@ -1762,7 +1784,7 @@ var Store = (_class = /*#__PURE__*/function () {
      * @return {Object} record
      */
     function () {
-      var _fetchOne = _asyncToGenerator__default["default"]( /*#__PURE__*/_regeneratorRuntime__default["default"].mark(function _callee3(type, id) {
+      var _fetchOne = _asyncToGenerator__default['default']( /*#__PURE__*/_regeneratorRuntime__default['default'].mark(function _callee3(type, id) {
         var options,
             queryParams,
             url,
@@ -1773,7 +1795,7 @@ var Store = (_class = /*#__PURE__*/function () {
             included,
             record,
             _args3 = arguments;
-        return _regeneratorRuntime__default["default"].wrap(function _callee3$(_context3) {
+        return _regeneratorRuntime__default['default'].wrap(function _callee3$(_context3) {
           while (1) {
             switch (_context3.prev = _context3.next) {
               case 0:
@@ -1837,7 +1859,7 @@ var Store = (_class = /*#__PURE__*/function () {
         }, _callee3, this);
       }));
 
-      function fetchOne(_x5, _x6) {
+      function fetchOne(_x4, _x5) {
         return _fetchOne.apply(this, arguments);
       }
 
@@ -1940,6 +1962,10 @@ var Store = (_class = /*#__PURE__*/function () {
       this.baseUrl = options.baseUrl || '';
       this.defaultFetchOptions = options.defaultFetchOptions || {};
       this.headersOfInterest = options.headersOfInterest || [];
+      this.retryOptions = options.retryOptions || {
+        attempts: 1,
+        delay: 0
+      }; // default to no retry
     }
     /**
      * Entry point for configuring the store
@@ -1993,32 +2019,20 @@ var Store = (_class = /*#__PURE__*/function () {
 
   }, {
     key: "fetch",
-    value: function (_fetch) {
-      function fetch(_x) {
-        return _fetch.apply(this, arguments);
-      }
-
-      fetch.toString = function () {
-        return _fetch.toString();
-      };
-
-      return fetch;
-    }(function (url) {
+    value: function fetch(url) {
       var _this3 = this;
 
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       var defaultFetchOptions = this.defaultFetchOptions,
-          headersOfInterest = this.headersOfInterest;
+          headersOfInterest = this.headersOfInterest,
+          retryOptions = this.retryOptions;
 
       var fetchOptions = _objectSpread$3(_objectSpread$3({}, defaultFetchOptions), options);
 
-      var key = JSON.stringify({
-        url: url,
-        fetchOptions: fetchOptions
-      });
-      return combineRacedRequests(key, function () {
-        return fetch(url, _objectSpread$3(_objectSpread$3({}, defaultFetchOptions), options));
-      }).then(function (response) {
+      var attempts = retryOptions.attempts,
+          delay = retryOptions.delay;
+
+      var handleResponse = function handleResponse(response) {
         // Capture headers of interest
         if (headersOfInterest) {
           mobx.runInAction(function () {
@@ -2031,7 +2045,9 @@ var Store = (_class = /*#__PURE__*/function () {
         }
 
         return response;
-      });
+      };
+
+      return fetchWithRetry(url, fetchOptions, attempts, delay).then(handleResponse);
     }
     /**
      * Gets type of collection from data observable
@@ -2040,7 +2056,7 @@ var Store = (_class = /*#__PURE__*/function () {
      * @param {String} type
      * @return {Object} observable type object structure
      */
-    )
+
   }, {
     key: "getType",
     value: function getType(type) {
@@ -2087,7 +2103,7 @@ var Store = (_class = /*#__PURE__*/function () {
       var records = Array.from(this.getType(type).records.values()).filter(function (value) {
         return value && value !== 'undefined';
       });
-      return uniqBy__default["default"](records, 'id');
+      return uniqBy__default['default'](records, 'id');
     }
     /**
      * Get multiple records by id
@@ -2320,10 +2336,10 @@ var Store = (_class = /*#__PURE__*/function () {
         record.isInFlight = true;
       });
       return promise.then( /*#__PURE__*/function () {
-        var _ref5 = _asyncToGenerator__default["default"]( /*#__PURE__*/_regeneratorRuntime__default["default"].mark(function _callee4(response) {
+        var _ref5 = _asyncToGenerator__default['default']( /*#__PURE__*/_regeneratorRuntime__default['default'].mark(function _callee4(response) {
           var status, json, data, included, _json, errorString;
 
-          return _regeneratorRuntime__default["default"].wrap(function _callee4$(_context4) {
+          return _regeneratorRuntime__default['default'].wrap(function _callee4$(_context4) {
             while (1) {
               switch (_context4.prev = _context4.next) {
                 case 0:
@@ -2425,7 +2441,7 @@ var Store = (_class = /*#__PURE__*/function () {
           }, _callee4, null, [[16, 22]]);
         }));
 
-        return function (_x7) {
+        return function (_x6) {
           return _ref5.apply(this, arguments);
         };
       }(), function (error) {
@@ -2440,21 +2456,21 @@ var Store = (_class = /*#__PURE__*/function () {
   }]);
 
   return Store;
-}(), (_descriptor = _applyDecoratedDescriptor__default["default"](_class.prototype, "data", [mobx.observable], {
+}(), (_descriptor = _applyDecoratedDescriptor__default['default'](_class.prototype, "data", [mobx.observable], {
   configurable: true,
   enumerable: true,
   writable: true,
   initializer: function initializer() {
     return {};
   }
-}), _descriptor2 = _applyDecoratedDescriptor__default["default"](_class.prototype, "lastResponseHeaders", [mobx.observable], {
+}), _descriptor2 = _applyDecoratedDescriptor__default['default'](_class.prototype, "lastResponseHeaders", [mobx.observable], {
   configurable: true,
   enumerable: true,
   writable: true,
   initializer: function initializer() {
     return {};
   }
-}), _descriptor3 = _applyDecoratedDescriptor__default["default"](_class.prototype, "addModel", [mobx.action], {
+}), _descriptor3 = _applyDecoratedDescriptor__default['default'](_class.prototype, "addModel", [mobx.action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2479,7 +2495,7 @@ var Store = (_class = /*#__PURE__*/function () {
       return model;
     };
   }
-}), _descriptor4 = _applyDecoratedDescriptor__default["default"](_class.prototype, "remove", [mobx.action], {
+}), _descriptor4 = _applyDecoratedDescriptor__default['default'](_class.prototype, "remove", [mobx.action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2490,7 +2506,7 @@ var Store = (_class = /*#__PURE__*/function () {
       _this8.data[type].records.delete(String(id));
     };
   }
-}), _descriptor5 = _applyDecoratedDescriptor__default["default"](_class.prototype, "setLoadingState", [mobx.action], {
+}), _descriptor5 = _applyDecoratedDescriptor__default['default'](_class.prototype, "setLoadingState", [mobx.action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2519,7 +2535,7 @@ var Store = (_class = /*#__PURE__*/function () {
       return loadingStateInfo;
     };
   }
-}), _descriptor6 = _applyDecoratedDescriptor__default["default"](_class.prototype, "deleteLoadingState", [mobx.action], {
+}), _descriptor6 = _applyDecoratedDescriptor__default['default'](_class.prototype, "deleteLoadingState", [mobx.action], {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2542,14 +2558,14 @@ var Store = (_class = /*#__PURE__*/function () {
       }
     };
   }
-}), _applyDecoratedDescriptor__default["default"](_class.prototype, "reset", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "reset"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "init", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "init"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "initializeNetworkConfiguration", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeNetworkConfiguration"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "initializeModelTypeIndex", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeModelTypeIndex"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "initializeObservableDataProperty", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeObservableDataProperty"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "createOrUpdateModel", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createOrUpdateModel"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "createModelsFromData", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createModelsFromData"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "createModel", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createModel"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "updateRecords", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "updateRecords"), _class.prototype)), _class);
+}), _applyDecoratedDescriptor__default['default'](_class.prototype, "reset", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "reset"), _class.prototype), _applyDecoratedDescriptor__default['default'](_class.prototype, "init", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "init"), _class.prototype), _applyDecoratedDescriptor__default['default'](_class.prototype, "initializeNetworkConfiguration", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeNetworkConfiguration"), _class.prototype), _applyDecoratedDescriptor__default['default'](_class.prototype, "initializeModelTypeIndex", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeModelTypeIndex"), _class.prototype), _applyDecoratedDescriptor__default['default'](_class.prototype, "initializeObservableDataProperty", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeObservableDataProperty"), _class.prototype), _applyDecoratedDescriptor__default['default'](_class.prototype, "createOrUpdateModel", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createOrUpdateModel"), _class.prototype), _applyDecoratedDescriptor__default['default'](_class.prototype, "createModelsFromData", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createModelsFromData"), _class.prototype), _applyDecoratedDescriptor__default['default'](_class.prototype, "createModel", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createModel"), _class.prototype), _applyDecoratedDescriptor__default['default'](_class.prototype, "updateRecords", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "updateRecords"), _class.prototype)), _class);
 
 var _excluded = ["type"],
     _excluded2 = ["type", "parent"];
 
 function ownKeys$2(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread$2(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$2(Object(source), true).forEach(function (key) { _defineProperty__default["default"](target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$2(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread$2(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$2(Object(source), true).forEach(function (key) { _defineProperty__default['default'](target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$2(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 /**
  * A class to create and use factories
  * @class FactoryFarm
@@ -2559,19 +2575,19 @@ var FactoryFarm = /*#__PURE__*/function () {
   function FactoryFarm(store) {
     var _this = this;
 
-    _classCallCheck__default["default"](this, FactoryFarm);
+    _classCallCheck__default['default'](this, FactoryFarm);
 
-    _defineProperty__default["default"](this, "factories", {});
+    _defineProperty__default['default'](this, "factories", {});
 
-    _defineProperty__default["default"](this, "singletons", {});
+    _defineProperty__default['default'](this, "singletons", {});
 
-    _defineProperty__default["default"](this, "add", function () {
+    _defineProperty__default['default'](this, "add", function () {
       var _this$store;
 
       return (_this$store = _this.store).add.apply(_this$store, arguments);
     });
 
-    _defineProperty__default["default"](this, "_verifyFactory", function (factoryName) {
+    _defineProperty__default['default'](this, "_verifyFactory", function (factoryName) {
       var factory = _this.factories[factoryName];
 
       if (!factory) {
@@ -2579,9 +2595,9 @@ var FactoryFarm = /*#__PURE__*/function () {
       }
     });
 
-    _defineProperty__default["default"](this, "_buildModel", function (factoryName, properties) {
+    _defineProperty__default['default'](this, "_buildModel", function (factoryName, properties) {
       var index = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-      properties = clone__default["default"](properties);
+      properties = clone__default['default'](properties);
       Object.keys(properties).forEach(function (key) {
         if (Array.isArray(properties[key])) {
           properties[key] = properties[key].map(function (propDefinition) {
@@ -2594,7 +2610,7 @@ var FactoryFarm = /*#__PURE__*/function () {
       return properties;
     });
 
-    _defineProperty__default["default"](this, "_callPropertyDefinition", function (definition, index, factoryName, properties) {
+    _defineProperty__default['default'](this, "_callPropertyDefinition", function (definition, index, factoryName, properties) {
       return typeof definition === 'function' ? definition.call(_this, index, factoryName, properties) : definition;
     });
 
@@ -2609,7 +2625,7 @@ var FactoryFarm = /*#__PURE__*/function () {
    */
 
 
-  _createClass__default["default"](FactoryFarm, [{
+  _createClass__default['default'](FactoryFarm, [{
     key: "build",
     value:
     /**
@@ -2645,7 +2661,7 @@ var FactoryFarm = /*#__PURE__*/function () {
 
       var _factories$factoryNam = factories[factoryName],
           type = _factories$factoryNam.type,
-          properties = _objectWithoutProperties__default["default"](_factories$factoryNam, _excluded);
+          properties = _objectWithoutProperties__default['default'](_factories$factoryNam, _excluded);
 
       var newModelProperties = _objectSpread$2(_objectSpread$2({
         id: function id(i) {
@@ -2672,7 +2688,7 @@ var FactoryFarm = /*#__PURE__*/function () {
       var addProperties;
 
       if (numberOfRecords > 1) {
-        addProperties = times__default["default"](numberOfRecords, function (i) {
+        addProperties = times__default['default'](numberOfRecords, function (i) {
           return _buildModel(factoryName, newModelProperties, i);
         });
       } else {
@@ -2709,7 +2725,7 @@ var FactoryFarm = /*#__PURE__*/function () {
 
       var type = options.type,
           parent = options.parent,
-          properties = _objectWithoutProperties__default["default"](options, _excluded2);
+          properties = _objectWithoutProperties__default['default'](options, _excluded2);
 
       var factory;
 
@@ -2772,7 +2788,7 @@ var addIncluded = function addIncluded(store, encodedModel, included) {
       var relatedModel = store.getOne(relationship.type, relationship.id);
       var encodedRelatedModel = toFullJsonapi(relatedModel);
       included.push(encodedRelatedModel);
-      addIncluded(store, encodedRelatedModel, included, [].concat(_toConsumableArray__default["default"](allEncoded), _toConsumableArray__default["default"](included), [encodedModel]));
+      addIncluded(store, encodedRelatedModel, included, [].concat(_toConsumableArray__default['default'](allEncoded), _toConsumableArray__default['default'](included), [encodedModel]));
     });
   });
 };
@@ -2819,7 +2835,7 @@ var serverResponse = function serverResponse(modelOrArray) {
       included: []
     };
     encodedData.data.forEach(function (encodedModel) {
-      addIncluded(array[0].store, encodedModel, encodedData.included, [].concat(_toConsumableArray__default["default"](encodedData.data), _toConsumableArray__default["default"](encodedData.included)));
+      addIncluded(array[0].store, encodedModel, encodedData.included, [].concat(_toConsumableArray__default['default'](encodedData.data), _toConsumableArray__default['default'](encodedData.included)));
     });
   } else {
     encodedData = {
@@ -2838,7 +2854,7 @@ var toFullJsonapi = function toFullJsonapi(model) {
 
 function ownKeys$1(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread$1(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$1(Object(source), true).forEach(function (key) { _defineProperty__default["default"](target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$1(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread$1(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys$1(Object(source), true).forEach(function (key) { _defineProperty__default['default'](target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys$1(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 var simulatePost = function simulatePost(store, type, body) {
   var attributes = JSON.parse(body.toString()).data.attributes;
@@ -2911,26 +2927,21 @@ var disallowFetches = function disallowFetches(store) {
   store.fetchAll = circularFindError;
   store.fetchMany = circularFindError;
 };
-
-var serverFailureStatuses = [500];
 /**
- * Wraps response JSON or object as needed. For a server failure (500), returns Promise.reject
- * For any other request, returns Promise.resolve wrapped around a Response object.
+ * Wraps response JSON or object in a Response object that is itself wrapped in a
+ * resolved Promise. If no status is given then it will fill in a default based on
+ * the method.
  * @method wrapResponse
- * @param {*} response JSON string unless a 500 error, in which case it's an object
+ * @param {*} response JSON string
  * @param {String} method
  * @param {Number} status
  * @return {Promise}
  */
 
+
 var wrapResponse = function wrapResponse(response, method, status) {
   if (!status) {
     status = method === 'POST' ? 201 : 200;
-  } // Simulate the server itself fails
-
-
-  if (serverFailureStatuses.includes(status)) {
-    return Promise.reject(response);
   }
 
   return Promise.resolve(new Response(response, {
@@ -2955,12 +2966,12 @@ function MockServer() {
 
   var _options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
-  _classCallCheck__default["default"](this, MockServer);
+  _classCallCheck__default['default'](this, MockServer);
 
-  _defineProperty__default["default"](this, "start", function () {
+  _defineProperty__default['default'](this, "start", function () {
     var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     var factoriesForTypes = options.factoriesForTypes;
-    var combinedOverrides = [].concat(_toConsumableArray__default["default"](options.responseOverrides || []), _toConsumableArray__default["default"](_this.responseOverrides || []));
+    var combinedOverrides = [].concat(_toConsumableArray__default['default'](options.responseOverrides || []), _toConsumableArray__default['default'](_this.responseOverrides || []));
     fetch.resetMocks();
     fetch.mockResponse(function (req) {
       var foundQuery = combinedOverrides.find(function (definition) {
@@ -2976,31 +2987,31 @@ function MockServer() {
     });
   });
 
-  _defineProperty__default["default"](this, "stop", function () {
+  _defineProperty__default['default'](this, "stop", function () {
     fetch.resetMocks();
 
     _this._backendFactoryFarm.store.reset();
   });
 
-  _defineProperty__default["default"](this, "build", function () {
+  _defineProperty__default['default'](this, "build", function () {
     var _this$_backendFactory;
 
     return (_this$_backendFactory = _this._backendFactoryFarm).build.apply(_this$_backendFactory, arguments);
   });
 
-  _defineProperty__default["default"](this, "define", function () {
+  _defineProperty__default['default'](this, "define", function () {
     var _this$_backendFactory2;
 
     return (_this$_backendFactory2 = _this._backendFactoryFarm).define.apply(_this$_backendFactory2, arguments);
   });
 
-  _defineProperty__default["default"](this, "add", function () {
+  _defineProperty__default['default'](this, "add", function () {
     var _this$_backendFactory3;
 
     return (_this$_backendFactory3 = _this._backendFactoryFarm).add.apply(_this$_backendFactory3, arguments);
   });
 
-  _defineProperty__default["default"](this, "_findFromStore", function (req) {
+  _defineProperty__default['default'](this, "_findFromStore", function (req) {
     var factoriesForTypes = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     var _backendFactoryFarm = _this._backendFactoryFarm;
     var method = req.method,
@@ -3170,13 +3181,13 @@ function validates(target, property) {
 
 var _Symbol$species;
 
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf__default["default"](Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf__default["default"](this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn__default["default"](this, result); }; }
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf__default['default'](Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf__default['default'](this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn__default['default'](this, result); }; }
 
 function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty__default["default"](target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty__default['default'](target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 /*
  * Defines a one-to-many relationship. Defaults to the class with camelized singular name of the property
  * An optional argument specifies the data model, if different from the property name
@@ -3281,7 +3292,7 @@ function getRelatedRecords(record, property) {
       }
     }
 
-    record.cachedRelationships = _objectSpread(_objectSpread({}, cachedRelationships), {}, _defineProperty__default["default"]({}, relationType, {
+    record.cachedRelationships = _objectSpread(_objectSpread({}, cachedRelationships), {}, _defineProperty__default['default']({}, relationType, {
       data: relatedRecords.map(function (r) {
         return {
           type: r.type,
@@ -3382,20 +3393,20 @@ function setRelatedRecord(record, relatedRecord, property) {
  */
 
 _Symbol$species = Symbol.species;
-var RelatedRecordsArray = /*#__PURE__*/function (_Array, _Symbol$species2) {
-  _inherits__default["default"](RelatedRecordsArray, _Array);
+var RelatedRecordsArray = /*#__PURE__*/function (_Array) {
+  _inherits__default['default'](RelatedRecordsArray, _Array);
 
   var _super = _createSuper(RelatedRecordsArray);
 
   function RelatedRecordsArray(_array, _record, _property) {
     var _this;
 
-    _classCallCheck__default["default"](this, RelatedRecordsArray);
+    _classCallCheck__default['default'](this, RelatedRecordsArray);
 
-    _this = _super.call.apply(_super, [this].concat(_toConsumableArray__default["default"](_array)));
+    _this = _super.call.apply(_super, [this].concat(_toConsumableArray__default['default'](_array)));
 
-    _defineProperty__default["default"](_assertThisInitialized__default["default"](_this), "add", function (relatedRecord) {
-      var _assertThisInitialize = _assertThisInitialized__default["default"](_this),
+    _defineProperty__default['default'](_assertThisInitialized__default['default'](_this), "add", function (relatedRecord) {
+      var _assertThisInitialize = _assertThisInitialized__default['default'](_this),
           record = _assertThisInitialize.record,
           property = _assertThisInitialize.property;
 
@@ -3441,8 +3452,8 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array, _Symbol$species2) {
       return relatedRecord;
     });
 
-    _defineProperty__default["default"](_assertThisInitialized__default["default"](_this), "remove", function (relatedRecord) {
-      var _assertThisInitialize2 = _assertThisInitialized__default["default"](_this),
+    _defineProperty__default['default'](_assertThisInitialized__default['default'](_this), "remove", function (relatedRecord) {
+      var _assertThisInitialize2 = _assertThisInitialized__default['default'](_this),
           record = _assertThisInitialize2.record,
           property = _assertThisInitialize2.property;
 
@@ -3477,8 +3488,8 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array, _Symbol$species2) {
       return relatedRecord;
     });
 
-    _defineProperty__default["default"](_assertThisInitialized__default["default"](_this), "replace", function (array) {
-      var _assertThisInitialize3 = _assertThisInitialized__default["default"](_this),
+    _defineProperty__default['default'](_assertThisInitialized__default['default'](_this), "replace", function (array) {
+      var _assertThisInitialize3 = _assertThisInitialized__default['default'](_this),
           record = _assertThisInitialize3.record,
           property = _assertThisInitialize3.property;
 
@@ -3510,8 +3521,8 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array, _Symbol$species2) {
    */
 
 
-  _createClass__default["default"](RelatedRecordsArray, null, [{
-    key: _Symbol$species2,
+  _createClass__default['default'](RelatedRecordsArray, null, [{
+    key: _Symbol$species,
     get: function get() {
       return Array;
     }
@@ -3525,7 +3536,7 @@ var RelatedRecordsArray = /*#__PURE__*/function (_Array, _Symbol$species2) {
   }]);
 
   return RelatedRecordsArray;
-}( /*#__PURE__*/_wrapNativeSuper__default["default"](Array), _Symbol$species);
+}( /*#__PURE__*/_wrapNativeSuper__default['default'](Array));
 
 exports.FactoryFarm = FactoryFarm;
 exports.MockServer = MockServer;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "license": "MIT",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",

--- a/spec/MockServer.spec.js
+++ b/spec/MockServer.spec.js
@@ -281,9 +281,7 @@ describe('MockServer', () => {
           path: /todos\/1/,
           method: 'PATCH',
           status: 500,
-          response: () => ({
-            title: 'You made a bad request.'
-          })
+          response: () => ''
         }
       ]
       mockServer.start({ responseOverrides })
@@ -293,7 +291,7 @@ describe('MockServer', () => {
       try {
         await user.save()
       } catch (error) {
-        expect(user.errors.title).toEqual('You made a bad request.')
+        expect(error.message).toEqual('Something went wrong.')
         expect(fetch.mock.calls).toHaveLength(1)
       }
     })

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -25,12 +25,11 @@ describe('deriveIdQueryStrings', () => {
 
 // function fetchWithRetry (url, fetchOptions, retryAttempts, delay, handleResponse) {
 describe('fetchWithRetry', () => {
-  let url, fetchOptions, handleResponse
+  let url, fetchOptions
 
   beforeEach(() => {
     url = 'https://example.com'
     fetchOptions = {}
-    handleResponse = (result) => result
     fetch.resetMocks()
   })
 
@@ -38,7 +37,7 @@ describe('fetchWithRetry', () => {
     expect.assertions(1)
 
     fetch.mockReject('network error')
-    await fetchWithRetry(url, fetchOptions, 2, 0, handleResponse).catch((_error) => {
+    await fetchWithRetry(url, fetchOptions, 2, 0).catch((_error) => {
       expect(fetch.mock.calls.length).toEqual(2)
     })
   })
@@ -47,7 +46,7 @@ describe('fetchWithRetry', () => {
     expect.assertions(1)
 
     fetch.mockReject('network error')
-    await fetchWithRetry(url, fetchOptions, 5, 0, handleResponse).catch((_error) => {
+    await fetchWithRetry(url, fetchOptions, 5, 0).catch((_error) => {
       expect(fetch.mock.calls.length).toEqual(5)
     })
   })
@@ -57,7 +56,7 @@ describe('fetchWithRetry', () => {
 
     fetch.mockRejectOnce('network error')
     fetch.mockResponseOnce('success')
-    await fetchWithRetry(url, fetchOptions, 5, 0, handleResponse).then((result) => {
+    await fetchWithRetry(url, fetchOptions, 5, 0).then((result) => {
       expect(result.body.toString()).toEqual('success')
       expect(fetch.mock.calls.length).toEqual(2)
     })

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -1,5 +1,6 @@
+/* global fetch */
 import QueryString from '../src/QueryString'
-import { deriveIdQueryStrings, URL_MAX_LENGTH } from '../src/utils'
+import { deriveIdQueryStrings, fetchWithRetry, URL_MAX_LENGTH } from '../src/utils'
 
 describe('deriveIdQueryStrings', () => {
   const shortIds = [1, 2, 3]
@@ -19,5 +20,46 @@ describe('deriveIdQueryStrings', () => {
     const idQueryStrings = deriveIdQueryStrings(shortIds, baseUrl)
     expect(idQueryStrings).toHaveLength(1)
     expect(idQueryStrings[0].length + baseUrl.length).toBeLessThan(URL_MAX_LENGTH)
+  })
+})
+
+// function fetchWithRetry (url, fetchOptions, retryAttempts, delay, handleResponse) {
+describe('fetchWithRetry', () => {
+  let url, fetchOptions, handleResponse
+
+  beforeEach(() => {
+    url = 'https://example.com'
+    fetchOptions = {}
+    handleResponse = (result) => result
+    fetch.resetMocks()
+  })
+
+  it('will retry the request if there is a fetch failure', async () => {
+    expect.assertions(1)
+
+    fetch.mockReject('network error')
+    await fetchWithRetry(url, fetchOptions, 2, 0, handleResponse).catch((_error) => {
+      expect(fetch.mock.calls.length).toEqual(2)
+    })
+  })
+
+  it('retries as many times as it is told', async () => {
+    expect.assertions(1)
+
+    fetch.mockReject('network error')
+    await fetchWithRetry(url, fetchOptions, 5, 0, handleResponse).catch((_error) => {
+      expect(fetch.mock.calls.length).toEqual(5)
+    })
+  })
+
+  it('stops retrying once it gets a successful response', async () => {
+    expect.assertions(2)
+
+    fetch.mockRejectOnce('network error')
+    fetch.mockResponseOnce('success')
+    await fetchWithRetry(url, fetchOptions, 5, 0, handleResponse).then((result) => {
+      expect(result.body.toString()).toEqual('success')
+      expect(fetch.mock.calls.length).toEqual(2)
+    })
   })
 })

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -34,15 +34,12 @@ describe('fetchWithRetry', () => {
   })
 
   it('will retry the request if there is a fetch failure', async () => {
-    expect.assertions(1)
-
-    fetch.mockReject('network error')
-    await fetchWithRetry(url, fetchOptions, 2, 0).catch((_error) => {
-      expect(fetch.mock.calls.length).toEqual(2)
-    })
+    fetch.mockRejectOnce('network error')
+    await fetchWithRetry(url, fetchOptions, 2, 0)
+    expect(fetch.mock.calls.length).toEqual(2)
   })
 
-  it('retries as many times as it is told', async () => {
+  it('makes as many requests as the attempts arguement calls for', async () => {
     expect.assertions(1)
 
     fetch.mockReject('network error')
@@ -56,9 +53,8 @@ describe('fetchWithRetry', () => {
 
     fetch.mockRejectOnce('network error')
     fetch.mockResponseOnce('success')
-    await fetchWithRetry(url, fetchOptions, 5, 0).then((result) => {
-      expect(result.body.toString()).toEqual('success')
-      expect(fetch.mock.calls.length).toEqual(2)
-    })
+    const result = await fetchWithRetry(url, fetchOptions, 5, 0)
+    expect(result.body.toString()).toEqual('success')
+    expect(fetch.mock.calls.length).toEqual(2)
   })
 })

--- a/src/MockServer.js
+++ b/src/MockServer.js
@@ -69,13 +69,12 @@ const disallowFetches = (store) => {
   store.fetchMany = circularFindError
 }
 
-const serverFailureStatuses = [500]
-
 /**
- * Wraps response JSON or object as needed. For a server failure (500), returns Promise.reject
- * For any other request, returns Promise.resolve wrapped around a Response object.
+ * Wraps response JSON or object in a Response object that is itself wrapped in a
+ * resolved Promise. If no status is given then it will fill in a default based on
+ * the method.
  * @method wrapResponse
- * @param {*} response JSON string unless a 500 error, in which case it's an object
+ * @param {*} response JSON string
  * @param {String} method
  * @param {Number} status
  * @return {Promise}
@@ -84,11 +83,6 @@ const serverFailureStatuses = [500]
 const wrapResponse = (response, method, status) => {
   if (!status) {
     status = method === 'POST' ? 201 : 200
-  }
-
-  // Simulate the server itself fails
-  if (serverFailureStatuses.includes(status)) {
-    return Promise.reject(response)
   }
 
   return Promise.resolve(new Response(response, { status }))

--- a/src/Store.js
+++ b/src/Store.js
@@ -659,6 +659,7 @@ class Store {
     this.baseUrl = options.baseUrl || ''
     this.defaultFetchOptions = options.defaultFetchOptions || {}
     this.headersOfInterest = options.headersOfInterest || []
+    this.retryOptions = options.retryOptions || { attempts: 1, delay: 0 } // do not retry by default
   }
 
   /**
@@ -708,13 +709,9 @@ class Store {
    * @param {Object} options
    */
   fetch (url, options = {}) {
-    const { defaultFetchOptions, headersOfInterest } = this
+    const { defaultFetchOptions, headersOfInterest, retryOptions } = this
     const fetchOptions = { ...defaultFetchOptions, ...options }
-
-    // TODO: extract these from options?
-    const retryAttempts = 3
-    // TODO: exponentially increase the delay on successive retry attempts?
-    const delay = 1000
+    const { attempts, delay } = retryOptions
 
     const handleResponse = (response) => {
       // Capture headers of interest
@@ -731,7 +728,7 @@ class Store {
       return response
     }
 
-    return fetchWithRetry(url, fetchOptions, retryAttempts, delay).then(handleResponse)
+    return fetchWithRetry(url, fetchOptions, attempts, delay).then(handleResponse)
   }
 
   /**

--- a/src/Store.js
+++ b/src/Store.js
@@ -710,10 +710,10 @@ class Store {
   fetch (url, options = {}) {
     const { defaultFetchOptions, headersOfInterest } = this
     const fetchOptions = { ...defaultFetchOptions, ...options }
-    const key = JSON.stringify({ url, fetchOptions })
 
     // TODO: extract these from options?
     const retryAttempts = 3
+    // TODO: exponentially increase the delay on successive retry attempts?
     const delay = 1000
 
     const handleResponse = (response) => {

--- a/src/Store.js
+++ b/src/Store.js
@@ -731,7 +731,7 @@ class Store {
       return response
     }
 
-    return fetchWithRetry(url, fetchOptions, retryAttempts, delay, handleResponse)
+    return fetchWithRetry(url, fetchOptions, retryAttempts, delay).then(handleResponse)
   }
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,16 +104,15 @@ export function combineRacedRequests (key, fn) {
     )
 }
 
-export function fetchWithRetry (url, fetchOptions, retryAttempts, delay, handleResponse) {
+export function fetchWithRetry (url, fetchOptions, retryAttempts, delay) {
   const key = JSON.stringify({ url, fetchOptions })
 
   return combineRacedRequests(key, () => fetch(url, fetchOptions))
-    .then(handleResponse) // TODO: chain this *after* the catch, that should work
     .catch(error => {
       const attemptsRemaining = retryAttempts - 1
       if (!attemptsRemaining) { throw error }
       return new Promise((resolve) => setTimeout(resolve, delay))
-        .then(() => fetchWithRetry(url, fetchOptions, attemptsRemaining, delay, handleResponse))
+        .then(() => fetchWithRetry(url, fetchOptions, attemptsRemaining, delay))
     })
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,7 +98,7 @@ export function combineRacedRequests (key, fn) {
     .then(
       // if there are other callers waiting for this request to resolve, clone the
       // response before returning so that we can re-use it for the remaining callers
-      response => pending[key] ? response.clone() : response,
+      response => response.clone(),
       // Bubble the error up to be handled by the consuming code
       error => Promise.reject(error)
     )

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,50 +82,39 @@ export function combineRacedRequests (key, fn) {
   // keep track of the number of callers waiting for this promise to resolve
   incrementBlocked()
 
-  function handleResponse (response) {
-    const count = decrementBlocked()
-    // if there are other callers waiting for this request to resolve, we should
-    // clone the response before returning so that we can re-use it for the
-    // remaining callers
-    if (count > 0) return response.clone()
-    // if there are no more callers waiting for this promise to resolve (i.e. if
-    // this is the last one), we can remove the reference to the pending promise
-    // allowing subsequent requests to proceed unblocked.
-    delete pending[key]
-    return response
-  }
-  function handleError (error) {
-    const count = decrementBlocked()
-    // if there are no more callers waiting for this promise to resolve (i.e. if
-    // this is the last one), we can remove the reference to the pending promise
-    // allowing subsequent requests to proceed unblocked.
-    if (count === 0) delete pending[key]
+  // Add the current call to our pending list in case another request comes in
+  // before it resolves. If there is a request already pending, we'll use the
+  // existing one instead
+  if (!pending[key]) { pending[key] = fn.call() }
 
-    // we do not need to clone the error, as it isn't single-use like response
-    // TODO: bubble this up as a rejected promise for the consuming application to handle
-    console.log(error.message)
-  }
-
-  // Return pending promise if one already exists
-  if (pending[key]) return pending[key].then(handleResponse, handleError)
-
-  // Otherwise call the method and on resolution
-  // clear out the pending promise for the key
-  pending[key] = fn.call()
-  return pending[key].then(handleResponse, handleError)
+  return pending[key]
+    .finally(() => {
+      const count = decrementBlocked()
+      // if there are no more callers waiting for this promise to resolve (i.e. if
+      // this is the last one), we can remove the reference to the pending promise
+      // allowing subsequent requests to proceed unblocked.
+      if (count === 0) delete pending[key]
+    })
+    .then(
+      // if there are other callers waiting for this request to resolve, clone the
+      // response before returning so that we can re-use it for the remaining callers
+      response => pending[key] ? response.clone() : response,
+      // Bubble the error up to be handled by the consuming code
+      error => Promise.reject(error)
+    )
 }
 
 export function fetchWithRetry (url, fetchOptions, retryAttempts, delay, handleResponse) {
   const key = JSON.stringify({ url, fetchOptions })
 
   return combineRacedRequests(key, () => fetch(url, fetchOptions))
-  .then(handleResponse)
-  .catch(error => {
-    const attemptsRemaining = retryAttempts - 1
-    if (!attemptsRemaining) { throw error }
-    return new Promise((resolve) => setTimeout(resolve, delay))
-               .then(() => fetchWithRetry(url, fetchOptions, attemptsRemaining, delay, handleResponse))
-  })
+    .then(handleResponse) // TODO: chain this *after* the catch, that should work
+    .catch(error => {
+      const attemptsRemaining = retryAttempts - 1
+      if (!attemptsRemaining) { throw error }
+      return new Promise((resolve) => setTimeout(resolve, delay))
+        .then(() => fetchWithRetry(url, fetchOptions, attemptsRemaining, delay, handleResponse))
+    })
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,12 +104,12 @@ export function combineRacedRequests (key, fn) {
     )
 }
 
-export function fetchWithRetry (url, fetchOptions, retryAttempts, delay) {
+export function fetchWithRetry (url, fetchOptions, attempts, delay) {
   const key = JSON.stringify({ url, fetchOptions })
 
   return combineRacedRequests(key, () => fetch(url, fetchOptions))
     .catch(error => {
-      const attemptsRemaining = retryAttempts - 1
+      const attemptsRemaining = attempts - 1
       if (!attemptsRemaining) { throw error }
       return new Promise((resolve) => setTimeout(resolve, delay))
         .then(() => fetchWithRetry(url, fetchOptions, attemptsRemaining, delay))


### PR DESCRIPTION
New configuration option to retry fetch attempts in the case of network failures.
When configuring the store, pass in `retryOptions` to `initializeNetworkConfiguration`
to set the number of total attempts and any delay between requests.

```
dataStore.initializeNetworkConfiguration({
  retryOptions: {
    attempts: 3,
    delay: 1000,
  }
})
```

`attempts`: The total number of attempts to make (default 1)
`delay`: Time to wait between failed attempts before retrying the request in milliseconds (default 0)