### PR TITLE
fix loading states observables

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -1692,6 +1692,8 @@ var Store = (_class = /*#__PURE__*/function () {
 
                 if (json.meta) {
                   records.meta = json.meta;
+
+                  _this.getType(type).meta.set(url, json.meta);
                 }
 
                 return _context2.abrupt("return", records);
@@ -1900,8 +1902,9 @@ var Store = (_class = /*#__PURE__*/function () {
     function reset(type) {
       if (type) {
         this.data[type] = {
-          records: mobx.observable.map({}),
-          cache: mobx.observable.map({})
+          records: mobx.observable.map(),
+          cache: mobx.observable.map(),
+          meta: mobx.observable.map()
         };
       } else {
         this.initializeObservableDataProperty();
@@ -1970,11 +1973,13 @@ var Store = (_class = /*#__PURE__*/function () {
 
       var types = this.constructor.types; // NOTE: Is there a performance cost to setting
       // each property individually?
+      // Is Map the most efficient structure?
 
       types.forEach(function (modelKlass) {
         _this2.data[modelKlass.type] = {
-          records: mobx.observable.map({}),
-          cache: mobx.observable.map({})
+          records: mobx.observable.map(),
+          cache: mobx.observable.map(),
+          meta: mobx.observable.map()
         };
       });
     }
@@ -2152,9 +2157,13 @@ var Store = (_class = /*#__PURE__*/function () {
       // Get the url the request would use
       var url = this.fetchUrl(type, queryParams, id); // Get the matching ids from the response
 
-      var ids = this.getCachedIds(type, url); // Get the records matching the ids
+      var ids = this.getCachedIds(type, url); // get the meta for the request
 
-      return this.getRecordsById(type, ids);
+      var meta = this.getType(type).meta.get(url); // Get the records matching the ids
+
+      var cachedRecords = this.getRecordsById(type, ids);
+      if (meta) cachedRecords.meta = meta;
+      return cachedRecords;
     }
     /**
      * Gets records from store based on cached query
@@ -2501,17 +2510,12 @@ var Store = (_class = /*#__PURE__*/function () {
         queryTag: queryTag
       };
 
-      var querySet = _this9.loadingStates.get(queryTag);
-
-      if (!querySet) {
-        querySet = mobx.observable.set([], {
-          deep: false
-        });
-
-        _this9.loadingStates.set(queryTag, querySet);
+      if (!_this9.loadingStates.get(queryTag)) {
+        _this9.loadingStates.set(queryTag, new Set());
       }
 
-      querySet.add(loadingStateInfo);
+      _this9.loadingStates.get(queryTag).add(JSON.stringify(loadingStateInfo));
+
       return loadingStateInfo;
     };
   }
@@ -2523,12 +2527,12 @@ var Store = (_class = /*#__PURE__*/function () {
     var _this10 = this;
 
     return function (state) {
-      var querySet = _this10.loadingStates.get(state.queryTag);
+      var loadingStates = _this10.loadingStates;
+      loadingStates.get(state.queryTag);
+      loadingStates.get(state.queryTag).delete(JSON.stringify(state));
 
-      querySet.delete(state);
-
-      if (querySet.size === 0) {
-        _this10.loadingStates.delete(state.queryTag);
+      if (loadingStates.get(state.queryTag).size === 0) {
+        loadingStates.delete(state.queryTag);
       }
     };
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "license": "MIT",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -770,7 +770,7 @@ describe('Store', () => {
       expect.assertions(2)
 
       fetch.mockResponseOnce(() => {
-        expect(toJS(store.loadingStates.get('loadingSpecialTodo'))).toMatchObject(new Set([{ queryTag: 'loadingSpecialTodo', type: 'todos', queryParams: undefined, url: '/example_api/todos/3' }]))
+        expect(toJS(store.loadingStates.get('loadingSpecialTodo'))).toMatchObject(new Set([JSON.stringify({ url: '/example_api/todos/3', type: 'todos', queryParams: undefined, queryTag: 'loadingSpecialTodo' })]))
         return Promise.resolve(mockTodoResponse)
       })
 
@@ -1075,7 +1075,7 @@ describe('Store', () => {
       expect.assertions(4)
 
       fetch.mockResponseOnce(() => {
-        expect(toJS(store.loadingStates.get('loadingSpecialTodos'))).toMatchObject(new Set([{ queryTag: 'loadingSpecialTodos', type: 'todos', queryParams: { a: 'b' }, url: '/example_api/todos?a=b' }]))
+        expect(toJS(store.loadingStates.get('loadingSpecialTodos'))).toMatchObject(new Set([JSON.stringify({ url: '/example_api/todos?a=b', type: 'todos', queryParams: { a: 'b' }, queryTag: 'loadingSpecialTodos' })]))
         expect(store.loadingTodos).toBe(false)
         return Promise.resolve(JSON.stringify({ data: [] }))
       })
@@ -1089,7 +1089,7 @@ describe('Store', () => {
       expect.assertions(4)
 
       fetch.mockResponseOnce(() => {
-        expect(toJS(store.loadingStates.get('todos'))).toMatchObject(new Set([{ queryTag: 'todos', type: 'todos', queryParams: undefined, url: '/example_api/todos' }]))
+        expect(toJS(store.loadingStates.get('todos'))).toMatchObject(new Set([JSON.stringify({ url: '/example_api/todos', type: 'todos', queryParams: undefined, queryTag: 'todos' })]))
         expect(store.loadingTodos).toBe(true)
         return Promise.resolve(JSON.stringify({ data: [] }))
       })
@@ -1103,14 +1103,14 @@ describe('Store', () => {
       expect.assertions(3)
 
     fetch.mockResponseOnce(() => {
-      expect(toJS(store.loadingStates.get('todos'))).toMatchObject(new Set([{ queryTag: 'todos', type: 'todos', queryParams: { a: 'b' }, url: '/example_api/todos?a=b' }]))
+      expect(toJS(store.loadingStates.get('todos'))).toMatchObject(new Set([JSON.stringify({ url: '/example_api/todos?a=b', type: 'todos', queryParams: { a: 'b' }, queryTag: 'todos' })]))
       return new Promise((resolve) => setTimeout(() => resolve(JSON.stringify({ data: [] })), 100))
     })
 
     fetch.mockResponseOnce(() => {
       expect(toJS(store.loadingStates.get('todos'))).toMatchObject(new Set([
-        { queryTag: 'todos', type: 'todos', queryParams: { a: 'b' }, url: '/example_api/todos?a=b' },
-        { queryTag: 'todos', type: 'todos', queryParams: { c: 'd' }, url: '/example_api/todos?c=d' }
+        JSON.stringify({ url: '/example_api/todos?a=b', type: 'todos', queryParams: { a: 'b' }, queryTag: 'todos' }),
+        JSON.stringify({ url: '/example_api/todos?c=d', type: 'todos', queryParams: { c: 'd' }, queryTag: 'todos' })
       ]))
       return Promise.resolve(JSON.stringify({ data: [] }))
     })
@@ -1200,7 +1200,7 @@ describe('Store', () => {
       expect.assertions(2)
 
       fetch.mockResponseOnce(() => {
-        expect(toJS(store.loadingStates.get('loadingSpecialTodos'))).toMatchObject(new Set([{ queryTag: 'loadingSpecialTodos', type: 'todos', queryParams: { filter: { ids: '1' } }, url: '/example_api/todos?filter%5Bids%5D=1' }]))
+        expect(toJS(store.loadingStates.get('loadingSpecialTodos'))).toMatchObject(new Set([JSON.stringify({ url: '/example_api/todos?filter%5Bids%5D=1', type: 'todos', queryParams: { filter: { ids: '1' } }, queryTag: 'loadingSpecialTodos' })]))
         return Promise.resolve(JSON.stringify({ data: [] }))
       })
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -470,7 +470,7 @@ class Store {
    *
    * const todos = store.fetchAll('todos', { queryTag: 'myTodos' })
    * store.loadingStates.get('myTodos')
-   * => Set([{ url, type, queryParams, queryTag }])
+   * => Set([JSON.stringify({ url, type, queryParams, queryTag })])
    *
    * @method setLoadingState
    * @param {Object} options options that can be used to build the loading state info
@@ -482,12 +482,11 @@ class Store {
 
     const loadingStateInfo = { url, type, queryParams, queryTag }
 
-    let querySet = this.loadingStates.get(queryTag)
-    if (!querySet) {
-      querySet = observable.set([], { deep: false })
-      this.loadingStates.set(queryTag, querySet)
+    if (!this.loadingStates.get(queryTag)) {
+      this.loadingStates.set(queryTag, new Set())
     }
-    querySet.add(loadingStateInfo)
+    this.loadingStates.get(queryTag).add(JSON.stringify(loadingStateInfo))
+
     return loadingStateInfo
   }
 
@@ -499,11 +498,12 @@ class Store {
    */
   @action
   deleteLoadingState = (state) => {
-    const querySet = this.loadingStates.get(state.queryTag)
+    const { loadingStates } = this
+    const { queryTag } = state
 
-    querySet.delete(state)
-    if (querySet.size === 0) {
-      this.loadingStates.delete(state.queryTag)
+    loadingStates.get(queryTag).delete(JSON.stringify(state))
+    if (loadingStates.get(queryTag).size === 0) {
+      loadingStates.delete(queryTag)
     }
   }
 


### PR DESCRIPTION
We have a `loadingStates` property in the datastore, which is an observable `Map` object keyed by a query tag, and with values of sets of query information that is added and removed as fetches start / complete.

Previously, the `Map` and `Set` were initialized separately, with the `Set` initialized as a `shallow` observable so that its objects would not be observable, and thus would not be proxied objects and could be compared directly.

```js
Map() // observable
  => Set() // observable
    => Object() // not observable
```

However, because mobx propagates observability down, this seems to have broken after a recent change in a [mobx Typescript interceptor](https://github.com/mobxjs/mobx/pull/3180/files#diff-e26ca35ba470ffd74d1efb4a9f1a1b25d726f8b200b899d5e86764b20951b2f2R28-R29)

This PR changes the data structure to initialize observability once, and change the query reference objects to JSON strings so that they will not be proxied themselves.

```js
Map() // observable
  => Set() // observable (by extension)
    => JSON String() // not observable
```