### PR TITLE
add a warning for a double call

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -2528,11 +2528,17 @@ var Store = (_class = /*#__PURE__*/function () {
 
     return function (state) {
       var loadingStates = _this10.loadingStates;
-      loadingStates.get(state.queryTag);
-      loadingStates.get(state.queryTag).delete(JSON.stringify(state));
+      var queryTag = state.queryTag;
+      var encodedState = JSON.stringify(state);
 
-      if (loadingStates.get(state.queryTag).size === 0) {
-        loadingStates.delete(state.queryTag);
+      if (loadingStates.get(queryTag)) {
+        loadingStates.get(queryTag).delete(encodedState);
+
+        if (loadingStates.get(queryTag).size === 0) {
+          loadingStates.delete(queryTag);
+        }
+      } else {
+        console.warn("no loadingState found for ".concat(encodedState));
       }
     };
   }

--- a/dist/mobx-async-store.esm.js
+++ b/dist/mobx-async-store.esm.js
@@ -2492,11 +2492,17 @@ var Store = (_class = /*#__PURE__*/function () {
 
     return function (state) {
       var loadingStates = _this10.loadingStates;
-      loadingStates.get(state.queryTag);
-      loadingStates.get(state.queryTag).delete(JSON.stringify(state));
+      var queryTag = state.queryTag;
+      var encodedState = JSON.stringify(state);
 
-      if (loadingStates.get(state.queryTag).size === 0) {
-        loadingStates.delete(state.queryTag);
+      if (loadingStates.get(queryTag)) {
+        loadingStates.get(queryTag).delete(encodedState);
+
+        if (loadingStates.get(queryTag).size === 0) {
+          loadingStates.delete(queryTag);
+        }
+      } else {
+        console.warn("no loadingState found for ".concat(encodedState));
       }
     };
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "license": "MIT",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -1132,6 +1132,24 @@ describe('Store', () => {
       expect(todos[0].notes).toHaveLength(0)
     })
 
+    it('only fetches once when called multiple times', async () => {
+      expect.assertions(2)
+
+      console.warn = jest.fn()
+      const mockResponseData = JSON.stringify({ data: [] })
+
+      fetch.mockResponseOnce(() => (new Promise((resolve) => setTimeout(() => resolve(mockResponseData), 100))))
+      fetch.mockResponseOnce(Promise.resolve(mockResponseData))
+
+      await Promise.all([
+        store.fetchAll('todos'),
+        store.fetchAll('todos')
+      ])
+
+      expect(fetch.mock.calls).toHaveLength(1)
+      expect(console.warn).toHaveBeenCalledWith('no loadingState found for {"url":"/example_api/todos","type":"todos","queryTag":"todos"}')
+    })
+
     it('supports queryParams', async () => {
       expect.assertions(2)
       fetch.mockResponse(mockTodosResponse)

--- a/src/Store.js
+++ b/src/Store.js
@@ -501,9 +501,15 @@ class Store {
     const { loadingStates } = this
     const { queryTag } = state
 
-    loadingStates.get(queryTag).delete(JSON.stringify(state))
-    if (loadingStates.get(queryTag).size === 0) {
-      loadingStates.delete(queryTag)
+    const encodedState = JSON.stringify(state)
+
+    if (loadingStates.get(queryTag)) {
+      loadingStates.get(queryTag).delete(encodedState)
+      if (loadingStates.get(queryTag).size === 0) {
+        loadingStates.delete(queryTag)
+      }
+    } else {
+      console.warn(`no loadingState found for ${encodedState}`)
     }
   }
 


### PR DESCRIPTION
If the same fetch params are used twice, the call is cached but the loadingState is attempted to delete twice.