### PR TITLE
configurable error messages

### DIFF
--- a/dist/mobx-async-store.cjs.js
+++ b/dist/mobx-async-store.cjs.js
@@ -262,6 +262,26 @@ function diff() {
   });
 }
 /**
+ * Parses JSONAPI error objects from a fetch response.
+ * If the response's body is undefined or is not formatted with a top-level `errors` key
+ * containing an array of errors, it builds a JSONAPI error object from the response status
+ * and a `errorMessages` configuration.
+ *
+ * Errors that are returned which contain a status also have their `detail` overridden with
+ * values from this configuration.
+ *
+ * @method parseErrors
+ * @param {Object} response
+ *   a fetch response
+ * @param {Object} errorMessages
+ *   store configuration of error messages corresponding to HTTP status codes
+ * @return Array<Object> An array of JSONAPI errors
+ */
+
+function parseErrors(_x, _x2) {
+  return _parseErrors.apply(this, arguments);
+}
+/**
  * Parses the pointer of the error to retrieve the index of the
  * record the error belongs to and the full path to the attribute
  * which will serve as the key for the error.
@@ -286,6 +306,78 @@ function diff() {
  * @param {Object} error
  * @return {Object} the matching parts of the pointer
  */
+
+function _parseErrors() {
+  _parseErrors = _asyncToGenerator__default["default"]( /*#__PURE__*/_regeneratorRuntime__default["default"].mark(function _callee(response, errorMessages) {
+    var json, statusError, _statusError, _statusError2;
+
+    return _regeneratorRuntime__default["default"].wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            json = {};
+            _context.prev = 1;
+            _context.next = 4;
+            return response.json();
+
+          case 4:
+            json = _context.sent;
+            _context.next = 11;
+            break;
+
+          case 7:
+            _context.prev = 7;
+            _context.t0 = _context["catch"](1);
+            // server doesn't return a parsable response
+            statusError = {
+              detail: errorMessages[response.status] || errorMessages.default,
+              status: response.status
+            };
+            return _context.abrupt("return", [statusError]);
+
+          case 11:
+            if (json.errors) {
+              _context.next = 14;
+              break;
+            }
+
+            _statusError = {
+              detail: errorMessages[response.status] || errorMessages.default,
+              status: response.status
+            };
+            return _context.abrupt("return", [_statusError]);
+
+          case 14:
+            if (Array.isArray(json.errors)) {
+              _context.next = 17;
+              break;
+            }
+
+            _statusError2 = {
+              detail: 'Top level errors in response are not an array.',
+              status: response.status
+            };
+            return _context.abrupt("return", [_statusError2]);
+
+          case 17:
+            return _context.abrupt("return", json.errors.map(function (error) {
+              // override or add the configured error message based on response status
+              if (error.status && errorMessages[error.status]) {
+                error.detail = errorMessages[error.status];
+              }
+
+              return error;
+            }));
+
+          case 18:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee, null, [[1, 7]]);
+  }));
+  return _parseErrors.apply(this, arguments);
+}
 
 function parseErrorPointer() {
   var error = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
@@ -851,7 +943,7 @@ var Model = (_class$1 = /*#__PURE__*/function () {
       _this.errors = {};
       return promise.then( /*#__PURE__*/function () {
         var _ref = _asyncToGenerator__default["default"]( /*#__PURE__*/_regeneratorRuntime__default["default"].mark(function _callee(response) {
-          var json;
+          var json, errors;
           return _regeneratorRuntime__default["default"].wrap(function _callee$(_context) {
             while (1) {
               switch (_context.prev = _context.next) {
@@ -900,14 +992,14 @@ var Model = (_class$1 = /*#__PURE__*/function () {
                   return _context.abrupt("return", _this);
 
                 case 17:
-                  mobx.runInAction(function () {
-                    _this.errors = {
-                      status: response.status
-                    };
-                  });
-                  return _context.abrupt("return", _this);
+                  _context.next = 19;
+                  return parseErrors(response, _this.store.errorMessages);
 
                 case 19:
+                  errors = _context.sent;
+                  throw new Error(JSON.stringify(errors));
+
+                case 21:
                 case "end":
                   return _context.stop();
               }
@@ -921,7 +1013,6 @@ var Model = (_class$1 = /*#__PURE__*/function () {
       }(), function (error) {
         // TODO: Handle error states correctly
         _this.isInFlight = false;
-        _this.errors = error;
         throw error;
       });
     }
@@ -1406,8 +1497,6 @@ var Store = (_class = /*#__PURE__*/function () {
 
     _defineProperty__default["default"](this, "loadedStates", mobx.observable.map());
 
-    _defineProperty__default["default"](this, "genericErrorMessage", 'Something went wrong.');
-
     _defineProperty__default["default"](this, "add", function (type, data) {
       if (data.constructor.name === 'Array') {
         return _this.addModels(type, data);
@@ -1671,6 +1760,7 @@ var Store = (_class = /*#__PURE__*/function () {
             response,
             json,
             records,
+            errors,
             _args = arguments;
         return _regeneratorRuntime__default["default"].wrap(function _callee$(_context) {
           while (1) {
@@ -1744,9 +1834,14 @@ var Store = (_class = /*#__PURE__*/function () {
                 mobx.runInAction(function () {
                   _this.deleteLoadingState(state);
                 });
-                return _context.abrupt("return", Promise.reject(response.status));
+                _context.next = 20;
+                return parseErrors(response, _this.errorMessages);
 
-              case 19:
+              case 20:
+                errors = _context.sent;
+                throw new Error(JSON.stringify(errors));
+
+              case 22:
               case "end":
                 return _context.stop();
             }
@@ -1814,6 +1909,7 @@ var Store = (_class = /*#__PURE__*/function () {
             data,
             included,
             record,
+            errors,
             _args2 = arguments;
         return _regeneratorRuntime__default["default"].wrap(function _callee2$(_context2) {
           while (1) {
@@ -1867,11 +1963,15 @@ var Store = (_class = /*#__PURE__*/function () {
                 return _context2.abrupt("return", record);
 
               case 22:
-                // TODO: return Promise.reject(response.status)
                 this.deleteLoadingState(state);
-                return _context2.abrupt("return", null);
+                _context2.next = 25;
+                return parseErrors(response, this.errorMessages);
 
-              case 24:
+              case 25:
+                errors = _context2.sent;
+                throw new Error(JSON.stringify(errors));
+
+              case 27:
               case "end":
                 return _context2.stop();
             }
@@ -1967,6 +2067,7 @@ var Store = (_class = /*#__PURE__*/function () {
       this.initializeNetworkConfiguration(options);
       this.initializeModelTypeIndex();
       this.initializeObservableDataProperty();
+      this.initializeErrorMessages(options);
     }
     /**
      * Entry point for configuring the store
@@ -2028,6 +2129,26 @@ var Store = (_class = /*#__PURE__*/function () {
           meta: mobx.observable.map()
         };
       });
+    }
+    /**
+     * Configure the error messages returned from the store when API requests fail
+     *
+     * @method initializeErrorMessages
+     * @param {Object} options for initializing the store
+     * @param {Object} options.errorMessages
+     *   options for initializing error messages for different HTTP status codes
+     */
+
+  }, {
+    key: "initializeErrorMessages",
+    value: function initializeErrorMessages() {
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+      var errorMessages = _objectSpread$3({}, options.errorMessages);
+
+      this.errorMessages = _objectSpread$3({
+        default: 'Something went wrong.'
+      }, errorMessages);
     }
     /**
      * Wrapper around fetch applies user defined fetch options
@@ -2357,8 +2478,7 @@ var Store = (_class = /*#__PURE__*/function () {
       });
       return promise.then( /*#__PURE__*/function () {
         var _ref4 = _asyncToGenerator__default["default"]( /*#__PURE__*/_regeneratorRuntime__default["default"].mark(function _callee3(response) {
-          var status, json, data, included, _json, errorString;
-
+          var status, json, data, included, errors;
           return _regeneratorRuntime__default["default"].wrap(function _callee3$(_context3) {
             while (1) {
               switch (_context3.prev = _context3.next) {
@@ -2402,63 +2522,35 @@ var Store = (_class = /*#__PURE__*/function () {
                   return _context3.abrupt("return", records);
 
                 case 15:
-                  _json = {};
-                  _context3.prev = 16;
-                  _context3.next = 19;
-                  return response.json();
+                  _context3.next = 17;
+                  return parseErrors(response, _this6.errorMessages);
 
-                case 19:
-                  _json = _context3.sent;
-                  _context3.next = 25;
-                  break;
-
-                case 22:
-                  _context3.prev = 22;
-                  _context3.t0 = _context3["catch"](16);
-                  return _context3.abrupt("return", Promise.reject(new Error(_this6.genericErrorMessage)));
-
-                case 25:
-                  if (_json.errors) {
-                    _context3.next = 27;
-                    break;
-                  }
-
-                  return _context3.abrupt("return", Promise.reject(new Error(_this6.genericErrorMessage)));
-
-                case 27:
-                  if (Array.isArray(_json.errors)) {
-                    _context3.next = 29;
-                    break;
-                  }
-
-                  return _context3.abrupt("return", Promise.reject(new TypeError('Top level errors in response are not an array.')));
-
-                case 29:
+                case 17:
+                  errors = _context3.sent;
                   mobx.runInAction(function () {
-                    _json.errors.forEach(function (error) {
+                    errors.forEach(function (error) {
                       var _parseErrorPointer = parseErrorPointer(error),
                           index = _parseErrorPointer.index,
                           key = _parseErrorPointer.key;
 
                       if (key != null) {
-                        var errors = recordsArray[index].errors[key] || [];
-                        errors.push(error);
-                        recordsArray[index].errors[key] = errors;
+                        // add the error to the record
+                        var _errors = recordsArray[index].errors[key] || [];
+
+                        _errors.push(error);
+
+                        recordsArray[index].errors[key] = _errors;
                       }
                     });
-
-                    errorString = recordsArray.map(function (record) {
-                      return JSON.stringify(record.errors);
-                    }).join(';');
                   });
-                  return _context3.abrupt("return", Promise.reject(new Error(errorString)));
+                  throw new Error(JSON.stringify(errors));
 
-                case 31:
+                case 20:
                 case "end":
                   return _context3.stop();
               }
             }
-          }, _callee3, null, [[16, 22]]);
+          }, _callee3);
         }));
 
         return function (_x4) {
@@ -2585,7 +2677,7 @@ var Store = (_class = /*#__PURE__*/function () {
       }
     };
   }
-}), _applyDecoratedDescriptor__default["default"](_class.prototype, "reset", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "reset"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "init", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "init"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "initializeNetworkConfiguration", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeNetworkConfiguration"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "initializeModelTypeIndex", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeModelTypeIndex"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "initializeObservableDataProperty", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeObservableDataProperty"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "createOrUpdateModel", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createOrUpdateModel"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "createModelsFromData", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createModelsFromData"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "createModel", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createModel"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "updateRecords", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "updateRecords"), _class.prototype)), _class);
+}), _applyDecoratedDescriptor__default["default"](_class.prototype, "reset", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "reset"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "init", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "init"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "initializeNetworkConfiguration", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeNetworkConfiguration"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "initializeModelTypeIndex", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeModelTypeIndex"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "initializeObservableDataProperty", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeObservableDataProperty"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "initializeErrorMessages", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "initializeErrorMessages"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "createOrUpdateModel", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createOrUpdateModel"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "createModelsFromData", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createModelsFromData"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "createModel", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "createModel"), _class.prototype), _applyDecoratedDescriptor__default["default"](_class.prototype, "updateRecords", [mobx.action], Object.getOwnPropertyDescriptor(_class.prototype, "updateRecords"), _class.prototype)), _class);
 
 var _excluded = ["type"],
     _excluded2 = ["type", "parent"];
@@ -3374,20 +3466,18 @@ function getRelatedRecords(record, property) {
  */
 
 function getRelatedRecord(record, property) {
-  var modelType = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
   // Get relationships
   var relationships = record.relationships; // Short circuit if no relationships are present
 
   if (!relationships) return; // Use property name unless model type is provided
 
-  var relationType = modelType ? singularizeType(modelType) : property;
-  var reference = relationships[relationType]; // Short circuit if matching reference is not found
+  var reference = relationships[property]; // Short circuit if matching reference is not found
 
   if (!reference || !reference.data) return;
   var _reference$data = reference.data,
       id = _reference$data.id,
       type = _reference$data.type;
-  var recordType = modelType || type;
+  var recordType = type;
   return record.store.getRecord(recordType, id);
 }
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "5.0.0",
+  "version": "5.0.0-rcjk-1",
   "license": "MIT",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "5.0.0-rcjk-1",
+  "version": "5.0.0",
   "license": "MIT",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artemisag/mobx-async-store",
-  "version": "4.10.0",
+  "version": "5.0.0",
   "license": "MIT",
   "module": "dist/mobx-async-store.esm.js",
   "browser": "dist/mobx-async-store.cjs.js",

--- a/spec/MockServer.spec.js
+++ b/spec/MockServer.spec.js
@@ -313,7 +313,7 @@ describe('MockServer', () => {
     })
 
     it('allows a simulated response for a server failure', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
       const responseOverrides = [
         {
           path: /todos\/1/,
@@ -329,7 +329,9 @@ describe('MockServer', () => {
       try {
         await todo.save()
       } catch (error) {
-        expect(error.message).toEqual('Something went wrong.')
+        const jsonError = JSON.parse(error.message)[0]
+        expect(jsonError.detail).toBe('Something went wrong.')
+        expect(jsonError.status).toBe(500)
         expect(fetch.mock.calls).toHaveLength(1)
       }
     })

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -1393,7 +1393,6 @@ describe('Model', () => {
           const jsonError = JSON.parse(error.message)[0]
           expect(jsonError.detail).toBe('Something went wrong.')
           expect(jsonError.status).toBe(500)
-          expect(error.name).toBe('Error')
         }
       })
 

--- a/spec/Model.spec.js
+++ b/spec/Model.spec.js
@@ -1382,5 +1382,54 @@ describe('Model', () => {
       expect(store.getAll('todos'))
         .toHaveLength(0)
     })
+
+    describe('error handling', () => {
+      it('rejects with the status', async () => {
+        fetch.mockResponses([JSON.stringify({}), { status: 500 }])
+        const todo = store.add('todos', { id: 1, title: 'Buy Milk' })
+        try {
+          await todo.destroy()
+        } catch (error) {
+          const jsonError = JSON.parse(error.message)[0]
+          expect(jsonError.detail).toBe('Something went wrong.')
+          expect(jsonError.status).toBe(500)
+          expect(error.name).toBe('Error')
+        }
+      })
+
+      it('uses the configured error message for the corresponding HTTP status code', async () => {
+        const store2 = new AppStore({
+          baseUrl: mockBaseUrl,
+          defaultFetchOptions: mockFetchOptions,
+          errorMessages: {
+            403: "You don't have permission to access this record.",
+            500: 'Oh no!',
+            default: 'Sorry.'
+          }
+        })
+
+        fetch.mockResponses([JSON.stringify({}), { status: 403 }])
+        const todo = store2.add('todos', { id: 1, title: 'Buy Milk' })
+
+        try {
+          await todo.destroy()
+        } catch (error) {
+          const jsonError = JSON.parse(error.message)[0]
+          expect(jsonError.detail).toBe("You don't have permission to access this record.")
+          expect(jsonError.status).toBe(403)
+          expect(error.name).toBe('Error')
+        }
+      })
+
+      it('does not remove the record from the store', async () => {
+        fetch.mockResponses([JSON.stringify({}), { status: 500 }])
+        const todo = store.add('todos', { id: 1, title: 'Buy Milk' })
+        try {
+          await todo.destroy()
+        } catch (error) {
+          expect(store.getAll('todos')).toHaveLength(1)
+        }
+      })
+    })
   })
 })

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -1464,12 +1464,16 @@ describe('Store', () => {
     })
 
     it('returns a rejected Promise with the status if fetching fails', async () => {
-      expect.assertions(2)
       fetch.mockResponse('', { status: 401 })
       const ids = createMockIds(5, '1000')
-      const query = store.fetchMany('todos', ids)
-      expect(query).toBeInstanceOf(Promise)
-      await expect(query).rejects.toEqual(401)
+      try {
+        await store.fetchMany('todos', ids)
+      } catch (error) {
+        const jsonError = JSON.parse(error.message)[0]
+        expect(jsonError.detail).toBe('Something went wrong.')
+        expect(jsonError.status).toBe(401)
+        expect(error.name).toBe('Error')
+      }
     })
 
     it('uses multiple fetches for data from server', async () => {

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -1262,9 +1262,14 @@ describe('Store', () => {
 
     it('returns a rejected Promise with the status if fetching fails', async () => {
       fetch.mockResponse('', { status: 401 })
-      const query = store.fetchAll('todos')
-      expect(query).toBeInstanceOf(Promise)
-      await expect(query).rejects.toEqual(401)
+      try {
+        await store.fetchAll('todos')
+      } catch (error) {
+        const jsonError = JSON.parse(error.message)[0]
+        expect(jsonError.detail).toBe('Something went wrong.')
+        expect(jsonError.status).toBe(401)
+        expect(error.name).toBe('Error')
+      }
     })
 
     it('allows setting a tag for a query', async () => {

--- a/spec/Store.spec.js
+++ b/spec/Store.spec.js
@@ -744,7 +744,6 @@ describe('Store', () => {
           const jsonError = JSON.parse(error.message)[0]
           expect(jsonError.detail).toBe('Top level errors in response are not an array.')
           expect(jsonError.status).toBe(422)
-          expect(error.name).toBe('TypeError')
         }
       })
 
@@ -759,7 +758,6 @@ describe('Store', () => {
           const jsonError = JSON.parse(error.message)[0]
           expect(jsonError.detail).toBe('Something went wrong.')
           expect(jsonError.status).toBe(422)
-          expect(error.name).toBe('Error')
         }
       })
     })
@@ -794,7 +792,6 @@ describe('Store', () => {
           const jsonError = JSON.parse(error.message)[0]
           expect(jsonError.detail).toBe("You don't have permission to access this record.")
           expect(jsonError.status).toBe(403)
-          expect(error.name).toBe('Error')
         }
 
         errors = [{ status: 500 }]
@@ -805,7 +802,6 @@ describe('Store', () => {
           const jsonError = JSON.parse(error.message)[0]
           expect(jsonError.detail).toBe('Oh no!')
           expect(jsonError.status).toBe(500)
-          expect(error.name).toBe('Error')
         }
       })
 
@@ -818,7 +814,6 @@ describe('Store', () => {
           const jsonError = JSON.parse(error.message)[0]
           expect(jsonError.detail).toBe('Sorry.')
           expect(jsonError.status).toBe(400)
-          expect(error.name).toBe('Error')
         }
       })
     })
@@ -946,7 +941,6 @@ describe('Store', () => {
           const jsonError = JSON.parse(error.message)[0]
           expect(jsonError.detail).toBe('Something went wrong.')
           expect(jsonError.status).toBe(500)
-          expect(error.name).toBe('Error')
         }
       })
 
@@ -969,7 +963,6 @@ describe('Store', () => {
           const jsonError = JSON.parse(error.message)[0]
           expect(jsonError.detail).toBe("You don't have permission to access this record.")
           expect(jsonError.status).toBe(403)
-          expect(error.name).toBe('Error')
         }
       })
     })

--- a/src/Model.js
+++ b/src/Model.js
@@ -8,7 +8,7 @@ import {
   runInAction
 } from 'mobx'
 
-import { diff, makeDate } from './utils'
+import { diff, makeDate, parseErrors } from './utils'
 
 import schema from './schema'
 import cloneDeep from 'lodash/cloneDeep'
@@ -458,11 +458,8 @@ class Model {
 
           return _this
         } else {
-          const error = {
-            detail: _this.store.errorMessages[response.status] || _this.store.genericErrorMessage,
-            status: response.status
-          }
-          throw new Error(JSON.stringify([error]))
+          const errors = await parseErrors(response, _this.store.errorMessages)
+          throw new Error(JSON.stringify(errors))
         }
       },
       function (error) {

--- a/src/Model.js
+++ b/src/Model.js
@@ -458,16 +458,16 @@ class Model {
 
           return _this
         } else {
-          runInAction(() => {
-            _this.errors = { status: response.status }
-          })
-          return _this
+          const error = {
+            detail: _this.store.errorMessages[response.status] || _this.store.genericErrorMessage,
+            status: response.status
+          }
+          throw new Error(JSON.stringify([error]))
         }
       },
       function (error) {
         // TODO: Handle error states correctly
         _this.isInFlight = false
-        _this.errors = error
         throw error
       }
     )

--- a/src/Store.js
+++ b/src/Store.js
@@ -627,7 +627,11 @@ class Store {
       runInAction(() => {
         this.deleteLoadingState(state)
       })
-      return Promise.reject(response.status)
+      const error = {
+        detail: this.errorMessages[response.status] || this.genericErrorMessage,
+        status: response.status
+      }
+      throw new Error(JSON.stringify([error]))
     }
   }
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -1102,17 +1102,17 @@ class Store {
           } catch (error) {
             // server doesn't return a parsable response
             const errorResponse = { detail: this.genericErrorMessage, status }
-            return Promise.reject(new Error(JSON.stringify([errorResponse])))
+            throw new Error(JSON.stringify([errorResponse]))
           }
 
           if (!json.errors) {
             const errorResponse = { detail: this.genericErrorMessage, status }
-            return Promise.reject(new Error(JSON.stringify([errorResponse])))
+            throw new Error(JSON.stringify([errorResponse]))
           }
 
           if (!Array.isArray(json.errors)) {
             const errorResponse = { detail: 'Top level errors in response are not an array.', status }
-            return Promise.reject(new TypeError(JSON.stringify([errorResponse])))
+            throw new TypeError(JSON.stringify([errorResponse]))
           }
 
           // Add all errors from the API response to the record(s).
@@ -1135,7 +1135,7 @@ class Store {
             })
           })
 
-          return Promise.reject(new Error(JSON.stringify(errorsArray)))
+          throw new Error(JSON.stringify(errorsArray))
         }
       },
       function (error) {

--- a/src/Store.js
+++ b/src/Store.js
@@ -55,8 +55,6 @@ class Store {
 
   loadedStates = observable.map()
 
-  genericErrorMessage = 'Something went wrong.'
-
   /**
    * Initializer for Store class
    *
@@ -713,6 +711,7 @@ class Store {
     this.initializeNetworkConfiguration(options)
     this.initializeModelTypeIndex()
     this.initializeObservableDataProperty()
+    this.initializeErrorMessages(options)
   }
 
   /**
@@ -766,6 +765,27 @@ class Store {
         meta: observable.map()
       }
     })
+  }
+
+  /**
+   * Configure the error messages returned from the store when API requests fail
+   *
+   * @method initializeErrorMessages
+   * @param {Object} options for initializing the store
+   * @param {Object} options.errorMessages
+   *   options for initializing error messages for different HTTP status codes
+   */
+  @action
+  initializeErrorMessages (options = {}) {
+    const errorMessages = { ...options.errorMessages }
+
+    this.genericErrorMessage = errorMessages.default || 'Something went wrong.'
+    delete errorMessages.default
+
+    this.errorMessages = {
+      500: this.genericErrorMessage,
+      ...errorMessages
+    }
   }
 
   /**
@@ -1068,6 +1088,8 @@ class Store {
           // on success, return the original record(s).
           // again - this may be a single record so preserve the structure
           return records
+        } else if (Object.prototype.hasOwnProperty.call(this.errorMessages, status)) {
+          return Promise.reject(new Error(this.errorMessages[status]))
         } else {
           let json = {}
           try {

--- a/src/Store.js
+++ b/src/Store.js
@@ -360,9 +360,12 @@ class Store {
       this.deleteLoadingState(state)
       return record
     } else {
-      // TODO: return Promise.reject(response.status)
       this.deleteLoadingState(state)
-      return null
+      const error = {
+        detail: this.errorMessages[response.status] || this.genericErrorMessage,
+        status: response.status
+      }
+      throw new Error(JSON.stringify([error]))
     }
   }
 
@@ -1094,18 +1097,18 @@ class Store {
             json = await response.json()
           } catch (error) {
             // server doesn't return a parsable response
-            const errorResponse = [{ detail: this.genericErrorMessage, status }]
-            return Promise.reject(new Error(JSON.stringify(errorResponse)))
+            const errorResponse = { detail: this.genericErrorMessage, status }
+            return Promise.reject(new Error(JSON.stringify([errorResponse])))
           }
 
           if (!json.errors) {
-            const errorResponse = [{ detail: this.genericErrorMessage, status }]
-            return Promise.reject(new Error(JSON.stringify(errorResponse)))
+            const errorResponse = { detail: this.genericErrorMessage, status }
+            return Promise.reject(new Error(JSON.stringify([errorResponse])))
           }
 
           if (!Array.isArray(json.errors)) {
-            const errorResponse = [{ detail: 'Top level errors in response are not an array.', status }]
-            return Promise.reject(new TypeError(JSON.stringify(errorResponse)))
+            const errorResponse = { detail: 'Top level errors in response are not an array.', status }
+            return Promise.reject(new TypeError(JSON.stringify([errorResponse])))
           }
 
           // Add all errors from the API response to the record(s).

--- a/src/utils.js
+++ b/src/utils.js
@@ -164,6 +164,22 @@ export function diff (a = {}, b = {}) {
   })).filter((x) => x)
 }
 
+/**
+ * Parses JSONAPI error objects from a fetch response.
+ * If the response's body is undefined or is not formatted with a top-level `errors` key
+ * containing an array of errors, it builds a JSONAPI error object from the response status
+ * and a `errorMessages` configuration.
+ *
+ * Errors that are returned which contain a status also have their `detail` overridden with
+ * values from this configuration.
+ *
+ * @method parseErrors
+ * @param {Object} response
+ *   a fetch response
+ * @param {Object} errorMessages
+ *   store configuration of error messages corresponding to HTTP status codes
+ * @return Array<Object> An array of JSONAPI errors
+ */
 export async function parseErrors (response, errorMessages) {
   let json = {}
   try {


### PR DESCRIPTION
Catch configured HTTP errors and reject updates to records with readable error messages.
This is a first approach to exposing the response status from Store fetches to the calling application.